### PR TITLE
Relocate bundled Python during installation

### DIFF
--- a/app_builder/build.py
+++ b/app_builder/build.py
@@ -138,6 +138,9 @@ def build_release(
         installer_hook_python_candidates = _installer_hook_python_candidates(
             project_root, config, remap_table
         )
+        installer_bundled_python_path = _installer_bundled_python_path(
+            project_root, config, remap_table
+        )
         _validate_installer_payload_contract(
             config,
             remap_table,
@@ -172,6 +175,7 @@ def build_release(
             "add_uninstaller": config.installer.add_uninstaller,
             "payload_archive": payload_archive.name,
             "hook_python_candidates": installer_hook_python_candidates,
+            "python_bundled_path": installer_bundled_python_path,
             "start_menu": [
                 {
                     "target": item.target,
@@ -525,6 +529,40 @@ def _installer_hook_python_candidates(
         if destination is not None:
             destinations.append(destination.as_posix().replace("/", "\\"))
     return destinations
+
+
+def _installer_bundled_python_path(
+    project_root: Path,
+    config: AppBuilderConfig,
+    remap_table: Mapping[Path, PurePosixPath],
+) -> str | None:
+    if config.python_bundled is None:
+        return None
+
+    bundled_root = (project_root / config.python_bundled.path).resolve()
+    source_python = bundled_python_executable(bundled_root).resolve()
+    source_config = (bundled_root / "pyvenv.cfg").resolve()
+    resolved_remaps = {
+        source.resolve(): destination for source, destination in remap_table.items()
+    }
+    installed_python = resolved_remaps.get(source_python)
+    installed_config = resolved_remaps.get(source_config)
+    if installed_python is None and installed_config is None:
+        return None
+    if installed_python is None or installed_config is None:
+        raise ValueError(
+            "An installed python_bundled runtime must include both its base "
+            "python.exe and pyvenv.cfg after remapping."
+        )
+
+    installed_root = installed_python.parent.parent
+    expected_config = installed_root / "pyvenv.cfg"
+    if installed_config.as_posix().casefold() != expected_config.as_posix().casefold():
+        raise ValueError(
+            "python_bundled remaps must preserve pyvenv.cfg beside the runtime's "
+            "python directory."
+        )
+    return installed_root.as_posix()
 
 
 def _validate_installer_payload_contract(

--- a/app_builder/installer_bundle.py
+++ b/app_builder/installer_bundle.py
@@ -353,6 +353,7 @@ try {
     Move-AppBuilderDirectory $StagingDir $InstallDir 'new staging directory'
     $MovedStaging = $true
 
+    Set-AppBuilderBundledPythonHome $Manifest $InstallDir
     Set-Content -LiteralPath (Join-Path $InstallDir $InstalledManifestName) -Value $EmbeddedManifestJson -Encoding UTF8
 """
         + uninstall_copy_block
@@ -646,6 +647,31 @@ function Set-AppBuilderEnvironment {
     $env:app_builder_install_directory = $InstallDir
     $env:app_builder_project_root = $InstallDir
     $env:app_builder_start_menu = $StartMenuDir
+}
+
+function Set-AppBuilderBundledPythonHome {
+    param($Manifest, [string]$InstallDir)
+    $RelativeRoot = Get-AppBuilderObjectProperty $Manifest 'python_bundled_path'
+    if ([string]::IsNullOrWhiteSpace([string]$RelativeRoot)) {
+        return
+    }
+    $PythonRoot = Resolve-AppBuilderPath ([string]$RelativeRoot) $InstallDir
+    if (-not (Test-AppBuilderPathInside $PythonRoot $InstallDir)) {
+        throw "Bundled Python path escapes the install directory: $RelativeRoot"
+    }
+    $PythonHome = Join-Path $PythonRoot 'python'
+    $BasePython = Join-Path $PythonHome 'python.exe'
+    $ConfigPath = Join-Path $PythonRoot 'pyvenv.cfg'
+    if (-not (Test-Path -LiteralPath $BasePython -PathType Leaf)) {
+        throw "Bundled Python executable was not found: $BasePython"
+    }
+    if (-not (Test-Path -LiteralPath $ConfigPath -PathType Leaf)) {
+        throw "Bundled Python pyvenv.cfg was not found: $ConfigPath"
+    }
+    $PortableHome = $PythonHome.Replace('\', '/')
+    $Contents = "home = $PortableHome`ninclude-system-site-packages = false`n"
+    $Utf8 = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($ConfigPath, $Contents, $Utf8)
 }
 
 function Expand-AppBuilderPayloadArchive {

--- a/docs/app-builder-help.html
+++ b/docs/app-builder-help.html
@@ -1314,7 +1314,7 @@ publications:
           <tbody>
             <tr>
               <td><code>python_bundled</code> enabled</td>
-              <td>NuGet Python is materialized under <code>bin/python</code>. Main dependencies are installed into that runtime.</td>
+              <td>NuGet Python is materialized under <code>bin/python</code>. Main dependencies are installed into that runtime. When selected for the installed payload, its <code>pyvenv.cfg</code> is relocated to the final install directory before post-install hooks run.</td>
             </tr>
             <tr>
               <td><code>python_venv</code> enabled with bundled Python</td>

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -96,6 +96,12 @@ must include `python_bundled.path`, normally `bin/python`, in
 `installer.paths.include`. The project venv is normally a build environment and
 is packaged only when selected deliberately.
 
+When bundled Python is selected, the manifest records its final install-relative
+root. After the payload reaches the installation directory, the installer
+rewrites that runtime's `pyvenv.cfg` to its installed `python` directory before
+running post-install hooks. Build-machine paths therefore cannot leak into
+`sys._base_executable`, and the installed runtime remains able to create venvs.
+
 Remap entries are source and destination pairs. Archive destinations are validated
 before either writer runs. ZIP and 7-Zip both reject absolute paths, traversal,
 Windows-reserved names, generated paths such as `version.txt`, case-insensitive
@@ -120,6 +126,7 @@ The release manifest is written next to the artifacts and embedded into the inst
 - uninstaller flag;
 - Start Menu entries;
 - install and uninstall hook argv lists;
+- the installed bundled-Python root when that runtime is in the payload;
 - included payload file records;
 - locked dependency and downloaded-tool provenance used for the build.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "app-builder"
-version = "1.3.0"
+version = "1.3.1"
 description = "Schema-first Windows application builder for Python-focused apps."
 readme = "README.md"
 requires-python = ">=3.11,<4.0"

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -339,6 +339,52 @@ build_hooks: {}
                 install_script,
             )
 
+    def test_installer_manifest_tracks_remapped_bundled_python_root(self) -> None:
+        with TemporaryDirectory() as temp_dir_str:
+            project_root = Path(temp_dir_str)
+            subprocess.run(
+                ["git", "init"], cwd=project_root, check=True, capture_output=True
+            )
+            bundled_root = project_root / "runtime"
+            bundled_python = bundled_root / "python" / "python.exe"
+            bundled_python.parent.mkdir(parents=True)
+            bundled_python.write_bytes(b"fixture")
+            (bundled_root / "pyvenv.cfg").write_text(
+                f"home = {(bundled_root / 'python').as_posix()}\n"
+                "include-system-site-packages = false\n",
+                encoding="utf-8",
+            )
+            (project_root / "app_builder.yaml").write_text(
+                """
+app_builder_version: current
+python_bundled:
+  python_version: 3.13.5
+  path: runtime
+python_venv: null
+installer:
+  name: Bundled Python Paths
+  install_directory: '%localappdata%\\BundledPythonPaths'
+  icon: ""
+  paths:
+    include: [runtime]
+    remap:
+      - [runtime, app/runtime]
+build_hooks: {}
+""".strip(),
+                encoding="utf-8",
+            )
+            environment = PythonEnvironmentResult(
+                python_bundled=bundled_python,
+                python_venv=None,
+            )
+            with patch(
+                "app_builder.build._run_dependency_stages", return_value=environment
+            ):
+                release = build_release(project_root, version="1.0.0")
+
+            manifest = json.loads(release.manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual("app/runtime", manifest["python_bundled_path"])
+
     def test_zip_release_rejects_unsafe_or_colliding_remap_destinations(self) -> None:
         with TemporaryDirectory() as temp_dir_str:
             project_root = Path(temp_dir_str)

--- a/test/test_installer_bundle.py
+++ b/test/test_installer_bundle.py
@@ -367,6 +367,7 @@ class TestExeWrapInstallerBundle(unittest.TestCase):
                 )
                 self.assertIn("New-AppBuilderStartMenuShortcuts", install_ps1)
                 self.assertIn("Invoke-AppBuilderHookList", install_ps1)
+                self.assertIn("Set-AppBuilderBundledPythonHome", install_ps1)
                 self.assertLess(
                     install_ps1.index(
                         "Set-AppBuilderUninstallRegistryEntry $Manifest $InstallDir $UninstallRegistryPath"

--- a/test/test_installer_failure_modes.py
+++ b/test/test_installer_failure_modes.py
@@ -34,26 +34,25 @@ def _write_manifest(
     install_dir: Path,
     payload_name: str,
     install_hooks: dict[str, list[list[str]]] | None = None,
+    python_bundled_path: str | None = None,
 ) -> None:
-    path.write_text(
-        json.dumps(
-            {
-                "name": name,
-                "version": version,
-                "install_directory": str(install_dir),
-                "payload_archive": payload_name,
-                "start_menu": [],
-                "install_hooks": install_hooks
-                or {
-                    "pre_install": [],
-                    "post_install": [],
-                    "pre_uninstall": [],
-                    "post_uninstall": [],
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
+    manifest = {
+        "name": name,
+        "version": version,
+        "install_directory": str(install_dir),
+        "payload_archive": payload_name,
+        "start_menu": [],
+        "install_hooks": install_hooks
+        or {
+            "pre_install": [],
+            "post_install": [],
+            "pre_uninstall": [],
+            "post_uninstall": [],
+        },
+    }
+    if python_bundled_path is not None:
+        manifest["python_bundled_path"] = python_bundled_path
+    path.write_text(json.dumps(manifest), encoding="utf-8")
 
 
 def _write_payload(path: Path, files: dict[str, str]) -> None:
@@ -159,6 +158,48 @@ def _remove_registry_entries_for_install(install_dir: Path) -> None:
 
 @unittest.skipIf(os.name != "nt", "generated installer scripts target Windows")
 class TestInstallerFailureModes(unittest.TestCase):
+    def test_install_relocates_bundled_python_configuration(self) -> None:
+        with TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            appdata_dir = temp_dir / "appdata"
+            install_dir = temp_dir / "installed app"
+            payload = temp_dir / "payload.zip"
+            _write_payload(
+                payload,
+                {
+                    "runtime/pyvenv.cfg": (
+                        "home = C:/developer/machine/bin/python\n"
+                        "include-system-site-packages = false\n"
+                    ),
+                    "runtime/python/python.exe": "fixture",
+                },
+            )
+            manifest = temp_dir / "manifest.json"
+            _write_manifest(
+                manifest,
+                name="Relocatable Python",
+                version="1.0",
+                install_dir=install_dir,
+                payload_name=payload.name,
+                python_bundled_path="runtime",
+            )
+            extraction_dir = _build_and_extract_installer(
+                temp_dir, payload=payload, manifest=manifest
+            )
+
+            result = _run_install(extraction_dir, appdata_dir=appdata_dir)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            expected_home = (install_dir / "runtime" / "python").as_posix()
+            self.assertEqual(
+                f"home = {expected_home}\ninclude-system-site-packages = false\n",
+                (install_dir / "runtime" / "pyvenv.cfg").read_text(encoding="utf-8"),
+            )
+            self.assertNotIn(
+                "developer/machine",
+                (install_dir / "runtime" / "pyvenv.cfg").read_text(encoding="utf-8"),
+            )
+
     def test_legacy_upgrade_removes_validated_registry_and_vendor_shortcut(
         self,
     ) -> None:

--- a/test/test_installer_failure_modes.py
+++ b/test/test_installer_failure_modes.py
@@ -190,14 +190,23 @@ class TestInstallerFailureModes(unittest.TestCase):
             result = _run_install(extraction_dir, appdata_dir=appdata_dir)
 
             self.assertEqual(0, result.returncode, result.stderr)
-            expected_home = (install_dir / "runtime" / "python").as_posix()
-            self.assertEqual(
-                f"home = {expected_home}\ninclude-system-site-packages = false\n",
-                (install_dir / "runtime" / "pyvenv.cfg").read_text(encoding="utf-8"),
+            installed_config = (install_dir / "runtime" / "pyvenv.cfg").read_text(
+                encoding="utf-8"
             )
+            lines = installed_config.splitlines()
+            self.assertEqual(2, len(lines))
+            self.assertTrue(lines[0].startswith("home = "))
+            installed_home = Path(lines[0].removeprefix("home = "))
+            self.assertTrue(
+                os.path.samefile(
+                    installed_home,
+                    install_dir / "runtime" / "python",
+                )
+            )
+            self.assertEqual("include-system-site-packages = false", lines[1])
             self.assertNotIn(
                 "developer/machine",
-                (install_dir / "runtime" / "pyvenv.cfg").read_text(encoding="utf-8"),
+                installed_config,
             )
 
     def test_legacy_upgrade_removes_validated_registry_and_vendor_shortcut(


### PR DESCRIPTION
## What changed

- records the final install-relative bundled-Python root in generated manifests
- rewrites the installed runtime's `pyvenv.cfg` after the payload reaches its final directory and before post-install hooks run
- validates that remaps preserve `pyvenv.cfg` beside the bundled runtime's `python` directory
- bumps the package version to 1.3.1 and documents the relocation contract

## Why

The 1.3.0 app-builder installer carried the build machine's absolute `python_bundled` path in `pyvenv.cfg`. Normal execution appeared healthy, but `sys._base_executable` still pointed into the source checkout. A clean Autory CI runner exposed this when the installed app-builder meta launcher attempted to create its managed-version venv and failed with WinError 2.

The installer is the correct relocation boundary because it knows the final install directory and can update every app-builder-generated bundled runtime before project post-install hooks use it.

## Validation

- full suite: 193 tests passed, 2 platform-specific skips
- Windows installation test replaces a deliberately stale `C:/developer/machine/...` home and verifies the exact installed path
- remapped-runtime build test verifies the generated manifest records the final payload root
- Black: 53 files clean
- MyPy: 53 source files clean
