### PR TITLE
Source complete Python runtimes from Python.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,12 @@ README is intentionally short. The release pipeline document exists separately b
 
 Normal builds verify an existing `poetry.lock` and install locked registry
 artifacts by SHA-256. They never rewrite the lock. Run `app-builder lock`
-deliberately when dependencies change. Python runtime versions must be exact
-`major.minor.patch` pins. Mutable Poetry `file` and `directory` dependencies are
-rejected for releases; use a hashed index artifact or a Git source pinned to a
-full resolved commit.
+deliberately when dependencies change. Complete Windows Python runtimes come
+from Python.org and are verified against its published SHA-256. Stable versions
+use exact `major.minor.patch` pins; prereleases also accept selectors such as
+`3.15.0-beta`. Mutable Poetry `file` and `directory` dependencies are rejected
+for releases; use a hashed index artifact or a Git source pinned to a full
+resolved commit.
 
 Use `%LOCALAPPDATA%`, `%APPDATA%`, or `%USERPROFILE%` as the root for install
 paths that must resolve on the end user's machine. Other variable-root install

--- a/app_builder/assets/app_builder_template.yaml
+++ b/app_builder/assets/app_builder_template.yaml
@@ -21,8 +21,9 @@ python_bundled:
   # materialized. Default if omitted: bin/python.
   path: bin/python
 
-  # Optional string. Exact major.minor.patch NuGet Python package version to materialize
-  # reproducibly. Default if omitted: 3.11.1.
+  # Optional string. Python.org Windows runtime version to materialize. Use
+  # major.minor.patch for a stable release; prereleases accept forms such as 3.15.0b4 or
+  # 3.15.0-beta. Default if omitted: 3.11.1.
   python_version: 3.12.10
 
 # Optional, nullable mapping | null. Optional Poetry dev virtual environment derived from
@@ -33,9 +34,9 @@ python_venv:
   # is created. Default if omitted: venv.
   path: venv
 
-  # Optional string. Exact major.minor.patch NuGet Python package version used when the
-  # virtual environment is self-contained because python_bundled is disabled. Default if
-  # omitted: 3.11.1.
+  # Optional string. Python.org Windows runtime version used when the virtual environment
+  # is self-contained because python_bundled is disabled. Prerelease selectors are
+  # supported. Default if omitted: 3.11.1.
   python_version: 3.12.10
 
 # Required mapping. Required installer metadata and release payload settings.

--- a/app_builder/python_runtime.py
+++ b/app_builder/python_runtime.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import base64
 import hashlib
 import json
 import os
@@ -29,15 +28,10 @@ from .poetry_dependencies import (
 )
 from .schema import PythonBundledOptions, PythonVenvOptions
 
-NUGET_PYTHON_PACKAGE_ID = "python"
-NUGET_FLAT_CONTAINER_BASE_URL = "https://api.nuget.org/v3-flatcontainer"
-NUGET_PYTHON_INDEX_URL = (
-    f"{NUGET_FLAT_CONTAINER_BASE_URL}/{NUGET_PYTHON_PACKAGE_ID}/index.json"
-)
-NUGET_REGISTRATION_BASE_URL = "https://api.nuget.org/v3/registration5-semver1"
-_VERSION_PATTERN_RE = re.compile(r"^\d+(?:\.\d+)*(?:[-+][0-9A-Za-z_.-]+)?$")
-_NUGET_SOURCE_MARKER = ".app-builder-python-source.json"
-_NUGET_PACKAGE_PAYLOAD_ROOT = "tools"
+PYTHON_RUNTIME_INDEX_URL = "https://www.python.org/ftp/python/index-windows.json"
+_PYTHON_RUNTIME_INDEX_ROOT = "https://www.python.org/ftp/python/"
+_VERSION_PATTERN_RE = re.compile(r"^\d+(?:\.\d+)*(?:(?:a|b|rc)\d+)?$")
+_PYTHON_SOURCE_MARKER = ".app-builder-python-source.json"
 EXE_WRAP_VERSION = "v2.1.0"
 _EXE_WRAP_RELEASE_BASE_URL = (
     f"https://github.com/AutoActuary/ExeWrap/releases/download/{EXE_WRAP_VERSION}"
@@ -54,7 +48,7 @@ _EXE_WRAP_SOURCE_MARKER = ".app-builder-exewrap-source.json"
 
 
 class PythonVersionNotFoundError(RuntimeError):
-    """Raised when NuGet does not offer a requested Python version."""
+    """Raised when Python.org does not offer a requested Python runtime."""
 
 
 def python_executable(venv_root: Path) -> Path:
@@ -101,7 +95,11 @@ def _matches_version_pattern(pattern: str | None, version: str) -> bool:
     cleaned = _normalized_version_pattern(pattern)
     if cleaned is None:
         return True
-    return version == cleaned or version.startswith(f"{cleaned}.")
+    if version == cleaned or version.startswith(f"{cleaned}."):
+        return True
+    if re.search(r"(?:a|b|rc)$", cleaned):
+        return re.fullmatch(re.escape(cleaned) + r"\d+", version) is not None
+    return False
 
 
 def _normalized_version_pattern(pattern: str | None) -> str | None:
@@ -112,15 +110,29 @@ def _normalized_version_pattern(pattern: str | None) -> str | None:
         return None
     if cleaned.endswith(".*"):
         cleaned = cleaned[:-2]
+    prerelease_match = re.search(
+        r"-(alpha|beta|candidate|rc)(?:[.-]?(\d+))?$",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    if prerelease_match:
+        prefix = {
+            "alpha": "a",
+            "beta": "b",
+            "candidate": "rc",
+            "rc": "rc",
+        }[prerelease_match.group(1).casefold()]
+        serial = prerelease_match.group(2) or ""
+        cleaned = cleaned[: prerelease_match.start()] + prefix + serial
     return cleaned
 
 
 def _is_prerelease_version(version: str) -> bool:
-    return "-" in version
+    return re.search(r"(?:a|b|rc)\d+$", version) is not None
 
 
 def _version_release_parts(version: str) -> tuple[int, ...] | None:
-    release = version.split("+", 1)[0].split("-", 1)[0]
+    release = re.split(r"(?:a|b|rc)\d+$", version, maxsplit=1)[0]
     parts = release.split(".")
     if not parts or not all(part.isdecimal() for part in parts):
         return None
@@ -133,9 +145,14 @@ def _padded_version_parts(version: str) -> tuple[int, int, int, int]:
     return (padded[0], padded[1], padded[2], padded[3])
 
 
-def _version_sort_key(version: str) -> tuple[tuple[int, int, int, int], int, str]:
+def _version_sort_key(
+    version: str,
+) -> tuple[tuple[int, int, int, int], int, int, int]:
     stable = 0 if _is_prerelease_version(version) else 1
-    return (_padded_version_parts(version), stable, version)
+    match = re.search(r"(a|b|rc)(\d+)$", version)
+    stage = {"a": 0, "b": 1, "rc": 2}.get(match.group(1), 3) if match else 3
+    serial = int(match.group(2)) if match else 0
+    return (_padded_version_parts(version), stable, stage, serial)
 
 
 def _latest_versions(versions: Sequence[str]) -> list[str]:
@@ -146,7 +163,7 @@ def _requested_version_parts(pattern: str | None) -> tuple[int, ...]:
     cleaned = _normalized_version_pattern(pattern)
     if cleaned is None:
         return ()
-    release = cleaned.split("+", 1)[0].split("-", 1)[0]
+    release = re.split(r"(?:a|b|rc)\d*$", cleaned, maxsplit=1)[0]
     parts: list[int] = []
     for part in release.split("."):
         if not part.isdecimal():
@@ -174,7 +191,7 @@ def _closest_versions(
     return sorted(versions, key=score)[:limit]
 
 
-def _suggest_nuget_python_versions(
+def _suggest_python_runtime_versions(
     versions: Sequence[str],
     python_version: str | None,
     *,
@@ -221,37 +238,8 @@ def _suggest_nuget_python_versions(
     return _latest_versions(suggestion_pool)[:limit]
 
 
-def _load_nuget_python_versions() -> list[str]:
-    request = urllib.request.Request(
-        NUGET_PYTHON_INDEX_URL,
-        headers={
-            "Accept": "application/json",
-            "User-Agent": "app-builder",
-        },
-    )
-    try:
-        with urllib.request.urlopen(request) as response:
-            payload: Any = json.loads(response.read().decode("utf-8"))
-    except urllib.error.URLError as error:
-        raise RuntimeError(
-            f"Could not query NuGet Python versions from {NUGET_PYTHON_INDEX_URL}: {error}."
-        ) from error
-
-    if not isinstance(payload, dict):
-        raise RuntimeError("Unexpected NuGet Python version response: expected object.")
-    versions = payload.get("versions")
-    if not isinstance(versions, list) or not all(
-        isinstance(version, str) for version in versions
-    ):
-        raise RuntimeError(
-            "Unexpected NuGet Python version response: expected a string version list."
-        )
-    return versions
-
-
-def _select_nuget_python_version(
-    versions: Sequence[str],
-    python_version: str | None,
+def _select_python_runtime_version(
+    versions: Sequence[str], python_version: str | None
 ) -> str:
     valid_versions = [
         version for version in versions if _VERSION_PATTERN_RE.match(version)
@@ -269,7 +257,7 @@ def _select_nuget_python_version(
     if matches:
         return _latest_versions(matches)[0]
 
-    suggestions = _suggest_nuget_python_versions(valid_versions, python_version)
+    suggestions = _suggest_python_runtime_versions(valid_versions, python_version)
     suggestion_text = ""
     if suggestions:
         suggestion_text = f" Closest available versions: {', '.join(suggestions)}."
@@ -279,23 +267,17 @@ def _select_nuget_python_version(
         else f"a version matching {python_version!r}"
     )
     raise PythonVersionNotFoundError(
-        f"NuGet package '{NUGET_PYTHON_PACKAGE_ID}' does not provide {requested}."
+        f"The Python.org Windows runtime index does not provide {requested}."
         f"{suggestion_text}"
     )
 
 
-def _nuget_python_download_url(version: str) -> str:
-    return (
-        f"{NUGET_FLAT_CONTAINER_BASE_URL}/{NUGET_PYTHON_PACKAGE_ID}/{version}/"
-        f"{NUGET_PYTHON_PACKAGE_ID}.{version}.nupkg"
-    )
-
-
 @dataclass(frozen=True, slots=True)
-class NuGetPythonPackage:
+class PythonRuntimePackage:
     version: str
+    runtime_id: str
     download_url: str
-    digest: str | None = None
+    digest: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -305,47 +287,20 @@ class ExeWrapPackage:
     digest: str | None
 
 
-def _resolve_nuget_python_package(python_version: str | None) -> NuGetPythonPackage:
-    versions = _load_nuget_python_versions()
-    selected_version = _select_nuget_python_version(versions, python_version)
-    return NuGetPythonPackage(
-        version=selected_version,
-        download_url=_nuget_python_download_url(selected_version),
-        digest=_load_nuget_python_digest(selected_version),
+def _python_runtime_architecture_tag() -> str:
+    machine = platform.machine().casefold()
+    if machine in {"amd64", "x86_64"}:
+        return "64"
+    if machine in {"arm64", "aarch64"}:
+        return "arm64"
+    if machine in {"x86", "i386", "i686"}:
+        return "32"
+    raise RuntimeError(
+        f"Python.org does not publish a Windows runtime for {machine!r}."
     )
 
 
-def _load_nuget_python_digest(version: str) -> str:
-    registration_url = (
-        f"{NUGET_REGISTRATION_BASE_URL}/{NUGET_PYTHON_PACKAGE_ID}/{version}.json"
-    )
-    registration = _load_nuget_json(registration_url)
-    catalog_url = registration.get("catalogEntry")
-    if not isinstance(catalog_url, str) or not catalog_url.startswith("https://"):
-        raise RuntimeError(
-            f"NuGet registration metadata did not provide a catalog entry for Python {version}."
-        )
-    catalog = _load_nuget_json(catalog_url)
-    algorithm = catalog.get("packageHashAlgorithm")
-    encoded = catalog.get("packageHash")
-    if algorithm != "SHA512" or not isinstance(encoded, str):
-        raise RuntimeError(
-            f"NuGet catalog metadata did not provide a SHA-512 package hash for Python {version}."
-        )
-    try:
-        digest = base64.b64decode(encoded, validate=True)
-    except ValueError as error:
-        raise RuntimeError(
-            f"NuGet returned an invalid SHA-512 package hash for Python {version}."
-        ) from error
-    if len(digest) != hashlib.sha512().digest_size:
-        raise RuntimeError(
-            f"NuGet returned an invalid SHA-512 package hash for Python {version}."
-        )
-    return "sha512:" + digest.hex()
-
-
-def _load_nuget_json(url: str) -> dict[str, Any]:
+def _load_python_index_json(url: str) -> dict[str, Any]:
     request = urllib.request.Request(
         url,
         headers={"Accept": "application/json", "User-Agent": "app-builder"},
@@ -355,11 +310,78 @@ def _load_nuget_json(url: str) -> dict[str, Any]:
             payload: Any = json.loads(response.read().decode("utf-8"))
     except (urllib.error.URLError, UnicodeDecodeError, json.JSONDecodeError) as error:
         raise RuntimeError(
-            f"Could not read NuGet metadata from {url}: {error}."
+            f"Could not read the Python.org Windows runtime index from {url}: {error}."
         ) from error
     if not isinstance(payload, dict):
-        raise RuntimeError(f"Unexpected NuGet metadata response from {url}.")
+        raise RuntimeError(f"Unexpected Python.org runtime index response from {url}.")
     return payload
+
+
+def _load_python_runtime_packages() -> list[PythonRuntimePackage]:
+    architecture = _python_runtime_architecture_tag()
+    packages: list[PythonRuntimePackage] = []
+    seen_urls: set[str] = set()
+    url: str | None = PYTHON_RUNTIME_INDEX_URL
+    while url is not None:
+        if url in seen_urls:
+            raise RuntimeError(f"Python.org runtime index contains a cycle at {url}.")
+        seen_urls.add(url)
+        payload = _load_python_index_json(url)
+        versions = payload.get("versions")
+        if not isinstance(versions, list):
+            raise RuntimeError(f"Python.org runtime index {url} has no version list.")
+        for entry in versions:
+            if not isinstance(entry, dict) or entry.get("company") != "PythonCore":
+                continue
+            version = entry.get("sort-version")
+            runtime_id = entry.get("id")
+            tag = entry.get("tag")
+            download_url = entry.get("url")
+            hash_info = entry.get("hash")
+            digest = hash_info.get("sha256") if isinstance(hash_info, dict) else None
+            if not (
+                isinstance(version, str)
+                and isinstance(runtime_id, str)
+                and isinstance(tag, str)
+                and tag.endswith(f"-{architecture}")
+                and isinstance(download_url, str)
+                and download_url.startswith(_PYTHON_RUNTIME_INDEX_ROOT)
+                and isinstance(digest, str)
+            ):
+                continue
+            packages.append(
+                PythonRuntimePackage(
+                    version=version,
+                    runtime_id=runtime_id,
+                    download_url=download_url,
+                    digest=f"sha256:{digest}",
+                )
+            )
+
+        next_index = payload.get("next")
+        if next_index is None:
+            url = None
+        elif isinstance(next_index, str):
+            url = urllib.parse.urljoin(url, next_index)
+            if not url.startswith(_PYTHON_RUNTIME_INDEX_ROOT):
+                raise RuntimeError(
+                    f"Python.org runtime index points outside python.org: {url}."
+                )
+        else:
+            raise RuntimeError(
+                f"Python.org runtime index {url} has an invalid next link."
+            )
+    return packages
+
+
+def _resolve_python_runtime_package(
+    python_version: str | None,
+) -> PythonRuntimePackage:
+    packages = _load_python_runtime_packages()
+    selected_version = _select_python_runtime_version(
+        [package.version for package in packages], python_version
+    )
+    return next(package for package in packages if package.version == selected_version)
 
 
 def _download_file(url: str, destination: Path) -> None:
@@ -371,7 +393,7 @@ def _download_file(url: str, destination: Path) -> None:
                 shutil.copyfileobj(response, output)
     except urllib.error.HTTPError as error:
         raise RuntimeError(
-            f"Could not download {url}: NuGet returned HTTP {error.code}."
+            f"Could not download {url}: server returned HTTP {error.code}."
         ) from error
     except urllib.error.URLError as error:
         raise RuntimeError(f"Could not download {url}: {error}.") from error
@@ -380,7 +402,7 @@ def _download_file(url: str, destination: Path) -> None:
 def _download_cache_path(url: str) -> Path:
     filename = Path(urllib.parse.urlsplit(url).path).name
     if not filename:
-        filename = f"{NUGET_PYTHON_PACKAGE_ID}.nupkg"
+        filename = "download"
     return Path(tempfile.gettempdir(), "app-builder-downloads", filename)
 
 
@@ -556,17 +578,18 @@ def _install_exe_wrap_python_launchers(
 
 
 def _source_marker_path(python_root: Path) -> Path:
-    return python_root / _NUGET_SOURCE_MARKER
+    return python_root / _PYTHON_SOURCE_MARKER
 
 
-def _write_nuget_source_marker(
+def _write_python_source_marker(
     python_root: Path,
-    package: NuGetPythonPackage,
+    package: PythonRuntimePackage,
 ) -> None:
     _source_marker_path(python_root).write_text(
         json.dumps(
             {
-                "package_id": NUGET_PYTHON_PACKAGE_ID,
+                "source": "python.org",
+                "runtime_id": package.runtime_id,
                 "version": package.version,
                 "download_url": package.download_url,
                 "digest": package.digest,
@@ -577,7 +600,7 @@ def _write_nuget_source_marker(
     )
 
 
-def _nuget_source_marker_matches(
+def _python_source_marker_matches(
     python_root: Path,
     python_version: str | None,
 ) -> bool:
@@ -590,11 +613,13 @@ def _nuget_source_marker_matches(
         return False
     if not isinstance(payload, dict):
         return False
-    package_id = payload.get("package_id")
+    source = payload.get("source")
+    runtime_id = payload.get("runtime_id")
     version = payload.get("version")
     digest = payload.get("digest")
     return (
-        package_id == NUGET_PYTHON_PACKAGE_ID
+        source == "python.org"
+        and isinstance(runtime_id, str)
         and isinstance(version, str)
         and _matches_version_pattern(python_version, version)
         and isinstance(digest, str)
@@ -610,19 +635,18 @@ def _safe_archive_target(root: Path, relative_parts: tuple[str, ...]) -> Path:
         destination_resolved.relative_to(root_resolved)
     except ValueError as error:
         raise RuntimeError(
-            f"NuGet Python package contains an unsafe archive path: {'/'.join(relative_parts)}."
+            "Python.org runtime package contains an unsafe archive path: "
+            f"{'/'.join(relative_parts)}."
         ) from error
     return destination
 
 
-def _extract_nuget_python_payload(package_path: Path, payload_root: Path) -> None:
+def _extract_python_runtime_payload(package_path: Path, payload_root: Path) -> None:
     extracted_any = False
     with ZipFile(package_path) as zip_file:
         for member in zip_file.infolist():
             parts = Path(member.filename).parts
-            if not parts or parts[0].lower() != _NUGET_PACKAGE_PAYLOAD_ROOT:
-                continue
-            relative_parts = tuple(parts[1:])
+            relative_parts = tuple(parts)
             if not relative_parts:
                 continue
             extracted_any = True
@@ -635,17 +659,36 @@ def _extract_nuget_python_payload(package_path: Path, payload_root: Path) -> Non
                 shutil.copyfileobj(source, destination)
 
     if not extracted_any:
-        raise RuntimeError("NuGet Python package did not contain a Python payload.")
+        raise RuntimeError(
+            "Python.org runtime package did not contain a Python payload."
+        )
 
 
-def _extract_nuget_python_package(package_path: Path, python_root: Path) -> None:
+def _extract_python_runtime_package(package_path: Path, python_root: Path) -> None:
     if python_root.exists():
         shutil.rmtree(python_root)
     with tempfile.TemporaryDirectory() as temp_dir_str:
         extracted_python = Path(temp_dir_str, "python-payload")
-        _extract_nuget_python_payload(package_path, extracted_python)
-        if not (extracted_python / "python.exe").exists():
-            raise RuntimeError("NuGet Python package did not contain python.exe.")
+        _extract_python_runtime_payload(package_path, extracted_python)
+        required_paths = (
+            "python.exe",
+            "pythonw.exe",
+            "Lib/os.py",
+            "Lib/ensurepip/__init__.py",
+            "Lib/venv/__init__.py",
+            "Lib/tkinter/__init__.py",
+            "DLLs/_tkinter.pyd",
+        )
+        missing = [
+            relative_path
+            for relative_path in required_paths
+            if not (extracted_python / relative_path).is_file()
+        ]
+        if missing:
+            raise RuntimeError(
+                "Python.org runtime package is incomplete; missing: "
+                + ", ".join(missing)
+            )
         site_packages = extracted_python / "Lib" / "site-packages"
         scripts = extracted_python / "Scripts"
 
@@ -692,12 +735,12 @@ def establish_bundled_python(
     python_executable = _bundled_python_executable(python_root)
     if not (
         _python_matches(python_executable, options.python_version)
-        and _nuget_source_marker_matches(python_root, options.python_version)
+        and _python_source_marker_matches(python_root, options.python_version)
     ):
-        package = _resolve_nuget_python_package(options.python_version)
+        package = _resolve_python_runtime_package(options.python_version)
         package_path = _ensure_downloaded_file(package.download_url, package.digest)
-        _extract_nuget_python_package(package_path, python_root)
-        _write_nuget_source_marker(python_root, package)
+        _extract_python_runtime_package(package_path, python_root)
+        _write_python_source_marker(python_root, package)
 
     python_executable = _bundled_python_executable(python_root)
     if not _python_matches(python_executable, options.python_version):
@@ -798,8 +841,8 @@ def _copy_bundled_runtime_support(bundled_root: Path, venv_root: Path) -> None:
         "python.exe",
         "pyvenv.cfg",
         "lib",
-        _NUGET_SOURCE_MARKER,
-        _NUGET_PACKAGE_PAYLOAD_ROOT,
+        "tools",
+        _PYTHON_SOURCE_MARKER,
     }
 
     def copy_included_files(source: Path = bundled_root) -> None:
@@ -850,7 +893,7 @@ def _self_contained_venv_matches(
             _self_contained_venv_python_executable(venv_root),
             python_version,
         )
-        and _nuget_source_marker_matches(venv_root, python_version)
+        and _python_source_marker_matches(venv_root, python_version)
         and _exe_wrap_source_marker_matches(venv_root)
         and _exe_wrap_launcher_matches(
             _self_contained_venv_launcher_executable(venv_root),
@@ -889,10 +932,10 @@ def _create_self_contained_venv(
     if venv_root.exists():
         shutil.rmtree(venv_root)
 
-    package = _resolve_nuget_python_package(options.python_version)
+    package = _resolve_python_runtime_package(options.python_version)
     package_path = _ensure_downloaded_file(package.download_url, package.digest)
-    _extract_nuget_python_package(package_path, venv_root)
-    _write_nuget_source_marker(venv_root, package)
+    _extract_python_runtime_package(package_path, venv_root)
+    _write_python_source_marker(venv_root, package)
     _ensure_pip(_self_contained_venv_python_executable(venv_root))
     _install_exe_wrap_python_launchers(venv_root)
     return _self_contained_venv_launcher_executable(venv_root)
@@ -1031,7 +1074,7 @@ def _python_environment_build_inputs(
             )
         for marker_root in marker_roots:
             for marker_name, kind in (
-                (_NUGET_SOURCE_MARKER, "nuget_python"),
+                (_PYTHON_SOURCE_MARKER, "python_runtime"),
                 (_EXE_WRAP_SOURCE_MARKER, "exewrap"),
             ):
                 marker_path = marker_root / marker_name

--- a/app_builder/schema.py
+++ b/app_builder/schema.py
@@ -9,7 +9,11 @@ from typing import Any, TypeAlias, cast
 from .schema_core import ConfigError as ConfigError, config_field, materialize_config
 
 HookCommand: TypeAlias = list[str]
-_EXACT_PYTHON_VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+_PYTHON_VERSION_SELECTOR = re.compile(
+    r"^[0-9]+\.[0-9]+\.[0-9]+"
+    r"(?:(?:a|b|rc)[0-9]+|-(?:alpha|beta|candidate|rc)(?:[.-]?[0-9]+)?)?$",
+    re.IGNORECASE,
+)
 
 
 @dataclass(slots=True)
@@ -21,7 +25,7 @@ class PythonBundledOptions:
     )
     python_version: str = config_field(
         default="3.11.1",
-        description="Exact major.minor.patch NuGet Python package version to materialize reproducibly.",
+        description="Python.org Windows runtime version to materialize. Use major.minor.patch for a stable release; prereleases accept forms such as 3.15.0b4 or 3.15.0-beta.",
         example="3.12.10",
     )
 
@@ -35,7 +39,7 @@ class PythonVenvOptions:
     )
     python_version: str = config_field(
         default="3.11.1",
-        description="Exact major.minor.patch NuGet Python package version used when the virtual environment is self-contained because python_bundled is disabled.",
+        description="Python.org Windows runtime version used when the virtual environment is self-contained because python_bundled is disabled. Prerelease selectors are supported.",
         example="3.12.10",
     )
 
@@ -313,11 +317,11 @@ def load_app_builder_config(
     ):
         if (
             options is not None
-            and _EXACT_PYTHON_VERSION.fullmatch(options.python_version) is None
+            and _PYTHON_VERSION_SELECTOR.fullmatch(options.python_version) is None
         ):
             raise ConfigError(
                 f"{path}.{section_name}.python_version",
-                "expected an exact major.minor.patch version.",
+                "expected major.minor.patch, optionally followed by a Python prerelease such as b4, rc1, or -beta.",
             )
     return config
 

--- a/docs/app-builder-1x-release-candidate-audit.html
+++ b/docs/app-builder-1x-release-candidate-audit.html
@@ -233,7 +233,7 @@
           <tr><td>ZIP and quiet 7z payloads with safe remaps and locked-file staging</td><td class="yes">Yes</td><td>Implemented and tested, including real 7z installation.</td></tr>
           <tr><td>Self-contained Windows install, upgrade, uninstall, hooks, shortcuts, and Installed Apps</td><td class="yes">Yes</td><td>Final-EXE tests cover clean install, argument-bearing upgrade hooks, registry updates, and uninstall cleanup.</td></tr>
           <tr><td>Multiple release assets and selected GitHub publication</td><td class="yes">Yes</td><td>Named output pickup is fresh and bounded; selected outputs, checksums, embedded payload, and manifest are verified together.</td></tr>
-          <tr><td>Reproducible Python materialization</td><td class="yes">Yes</td><td>Registry artifacts are hash-checked, Git sources require full commits, NuGet inputs are verified, and mutable path dependencies are refused.</td></tr>
+          <tr><td>Reproducible Python materialization</td><td class="yes">Yes</td><td>Registry artifacts are hash-checked, Git sources require full commits, Python.org runtime inputs are verified, and mutable path dependencies are refused.</td></tr>
           <tr><td>Version-aware current, managed 1.x, and explicit 0.x dispatch</td><td class="yes">Yes</td><td>The current process preserves cwd, avoids eager app imports, and exposes cache management.</td></tr>
           <tr><td>Installable Python package with usable documentation</td><td class="yes">Yes</td><td>The wheel test verified the packaged HTML help and the CLI's first-line link.</td></tr>
         </tbody>

--- a/docs/app-builder-1x-release-readiness-audit.html
+++ b/docs/app-builder-1x-release-readiness-audit.html
@@ -912,8 +912,8 @@ installer.exe
           <p>
             Every dependency run executes <code>poetry lock</code>, which may mutate the project and re-resolve rather
             than verify a committed lock. Installation then reconstructs <code>name==version</code> requirements and
-            uses pip <code>--no-deps</code> without Poetry artifact hashes. NuGet Python downloads are cached without a
-            repository-supplied digest, and self-contained venv launchers resolve the latest ExeWrap release at build
+            uses pip <code>--no-deps</code> without Poetry artifact hashes. Python runtime inputs lack an enforced
+            upstream digest, and self-contained venv launchers resolve the latest ExeWrap release at build
             time.
           </p>
           <p><strong>Required:</strong> verify an existing lock by default, add an explicit lock-refresh command,
@@ -923,8 +923,8 @@ installer.exe
             and release commands now require an existing <code>poetry.lock</code> and verify it with
             <code>poetry check --lock</code> without mutation; <code>app-builder lock</code> is the sole explicit refresh
             command. Registry and URL packages install from a temporary requirements file with Poetry's SHA-256 hashes
-            under pip <code>--require-hashes</code>, while Git packages require a full resolved commit. NuGet Python
-            packages are verified against NuGet's catalog SHA-512 hash, ExeWrap is pinned to v2.1.0 with per-architecture
+            under pip <code>--require-hashes</code>, while Git packages require a full resolved commit. Python.org runtime
+            packages are verified against the runtime index's SHA-256, ExeWrap is pinned to v2.1.0 with per-architecture
             SHA-256 digests, and the installer manifest records the selected lock, runtime, and launcher provenance.</p>
           <p class="source">Source: <a href="../app_builder/poetry_dependencies.py">poetry_dependencies.py:65</a>, <a href="../app_builder/python_runtime.py">python_runtime.py:346, 373, 822</a>.</p>
         </article>

--- a/docs/app-builder-help.html
+++ b/docs/app-builder-help.html
@@ -356,8 +356,9 @@ python_bundled:
   # materialized. Default if omitted: bin/python.
   path: bin/python
 
-  # Optional string. Exact major.minor.patch NuGet Python package version to materialize
-  # reproducibly. Default if omitted: 3.11.1.
+  # Optional string. Python.org Windows runtime version to materialize. Use
+  # major.minor.patch for a stable release; prereleases accept forms such as 3.15.0b4 or
+  # 3.15.0-beta. Default if omitted: 3.11.1.
   python_version: 3.12.10
 
 # Optional, nullable mapping | null. Optional Poetry dev virtual environment derived from
@@ -368,9 +369,9 @@ python_venv:
   # is created. Default if omitted: venv.
   path: venv
 
-  # Optional string. Exact major.minor.patch NuGet Python package version used when the
-  # virtual environment is self-contained because python_bundled is disabled. Default if
-  # omitted: 3.11.1.
+  # Optional string. Python.org Windows runtime version used when the virtual environment
+  # is self-contained because python_bundled is disabled. Prerelease selectors are
+  # supported. Default if omitted: 3.11.1.
   python_version: 3.12.10
 
 # Required mapping. Required installer metadata and release payload settings.
@@ -655,7 +656,7 @@ publications:
               <td>no</td>
               <td><code>3.11.1</code></td>
               <td><code>3.12.10</code></td>
-              <td>Exact major.minor.patch NuGet Python package version to materialize reproducibly.</td>
+              <td>Python.org Windows runtime version to materialize. Use major.minor.patch for a stable release; prereleases accept forms such as 3.15.0b4 or 3.15.0-beta.</td>
             </tr>
           </tbody>
         </table>
@@ -686,7 +687,7 @@ publications:
               <td>no</td>
               <td><code>3.11.1</code></td>
               <td><code>3.12.10</code></td>
-              <td>Exact major.minor.patch NuGet Python package version used when the virtual environment is self-contained because python_bundled is disabled.</td>
+              <td>Python.org Windows runtime version used when the virtual environment is self-contained because python_bundled is disabled. Prerelease selectors are supported.</td>
             </tr>
           </tbody>
         </table>
@@ -1314,7 +1315,7 @@ publications:
           <tbody>
             <tr>
               <td><code>python_bundled</code> enabled</td>
-              <td>NuGet Python is materialized under <code>bin/python</code>. Main dependencies are installed into that runtime. When selected for the installed payload, its <code>pyvenv.cfg</code> is relocated to the final install directory before post-install hooks run.</td>
+              <td>The complete Python.org Windows runtime is materialized under <code>bin/python</code>, including Tkinter, pip, venv, headers, and import libraries. Main dependencies are installed into that runtime. When selected for the installed payload, its <code>pyvenv.cfg</code> is relocated to the final install directory before post-install hooks run.</td>
             </tr>
             <tr>
               <td><code>python_venv</code> enabled with bundled Python</td>
@@ -1322,7 +1323,7 @@ publications:
             </tr>
             <tr>
               <td><code>python_venv</code> enabled without bundled Python</td>
-              <td>A self-contained NuGet-backed venv is created. Main and dev dependencies are installed into it.</td>
+              <td>A self-contained venv is created from the complete Python.org Windows runtime. Main and dev dependencies are installed into it.</td>
             </tr>
             <tr>
               <td>Both disabled</td>
@@ -1331,12 +1332,13 @@ publications:
           </tbody>
         </table>
         <p>
-          Python versions must use an exact <code>major.minor.patch</code> pin. Normal builds verify an existing
+          Stable Python versions use an exact <code>major.minor.patch</code> pin. Python prereleases may use an exact
+          form such as <code>3.15.0b4</code>, or a release-level selector such as <code>3.15.0-beta</code>. Normal builds verify an existing
           <code>poetry.lock</code> and install locked registry artifacts by SHA-256; use <code>app-builder lock</code>
           when dependency declarations change. Git sources require a full resolved commit. Mutable Poetry
           <code>file</code> and <code>directory</code> sources are rejected; publish a hashed artifact or use a
-          pinned Git source instead. Downloaded NuGet packages are cached under
-          <code>%TEMP%\app-builder-downloads</code> and verified against the SHA-512 digest published in NuGet catalog metadata.
+          pinned Git source instead. Complete Python runtimes are selected from Python.org's Windows runtime index,
+          cached under <code>%TEMP%\app-builder-downloads</code>, and verified against the SHA-256 published in that index.
         </p>
       </section>
 
@@ -1725,10 +1727,10 @@ build_hooks:
           variable that exists, <code>${GIT.*}</code> needs a readable git repository, and
           <code>${CONFIG.*}</code> must point at another string value without forming a cycle.
         </p>
-        <h3>NuGet Python version missing</h3>
+        <h3>Python runtime version missing</h3>
         <p>
-          Pin an exact available version such as <code>3.12.10</code>. Prefixes and wildcards are rejected so the
-          same config cannot silently select a newer runtime later.
+          Pin an available stable version such as <code>3.12.10</code>, or a Python prerelease such as
+          <code>3.15.0b4</code>. A selector such as <code>3.15.0-beta</code> chooses the latest matching beta.
         </p>
         <h3>GitHub release failed</h3>
         <p>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,8 +32,9 @@ python_bundled:
   # materialized. Default if omitted: bin/python.
   path: bin/python
 
-  # Optional string. Exact major.minor.patch NuGet Python package version to materialize
-  # reproducibly. Default if omitted: 3.11.1.
+  # Optional string. Python.org Windows runtime version to materialize. Use
+  # major.minor.patch for a stable release; prereleases accept forms such as 3.15.0b4 or
+  # 3.15.0-beta. Default if omitted: 3.11.1.
   python_version: 3.12.10
 
 # Optional, nullable mapping | null. Optional Poetry dev virtual environment derived from
@@ -44,9 +45,9 @@ python_venv:
   # is created. Default if omitted: venv.
   path: venv
 
-  # Optional string. Exact major.minor.patch NuGet Python package version used when the
-  # virtual environment is self-contained because python_bundled is disabled. Default if
-  # omitted: 3.11.1.
+  # Optional string. Python.org Windows runtime version used when the virtual environment
+  # is self-contained because python_bundled is disabled. Prerelease selectors are
+  # supported. Default if omitted: 3.11.1.
   python_version: 3.12.10
 
 # Required mapping. Required installer metadata and release payload settings.
@@ -270,14 +271,14 @@ installer:
 | Field | Type | Required | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
 | `path` | `string` | no | `bin/python` | `bin/python` | Project-relative directory where the bundled Python runtime is materialized. |
-| `python_version` | `string` | no | `3.11.1` | `3.12.10` | Exact major.minor.patch NuGet Python package version to materialize reproducibly. |
+| `python_version` | `string` | no | `3.11.1` | `3.12.10` | Python.org Windows runtime version to materialize. Use major.minor.patch for a stable release; prereleases accept forms such as 3.15.0b4 or 3.15.0-beta. |
 
 ## `config.python_venv`
 
 | Field | Type | Required | Default | Example | Description |
 | --- | --- | --- | --- | --- | --- |
 | `path` | `string` | no | `venv` | `venv` | Project-relative directory where the Poetry dev virtual environment is created. |
-| `python_version` | `string` | no | `3.11.1` | `3.12.10` | Exact major.minor.patch NuGet Python package version used when the virtual environment is self-contained because python_bundled is disabled. |
+| `python_version` | `string` | no | `3.11.1` | `3.12.10` | Python.org Windows runtime version used when the virtual environment is self-contained because python_bundled is disabled. Prerelease selectors are supported. |
 
 ## `config.installer`
 

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -60,8 +60,9 @@ Python dependencies come from `pyproject.toml` and an existing `poetry.lock`.
 Normal builds run Poetry's read-only lock check and never regenerate the lock;
 `app-builder lock` is the explicit lock-changing command. Registry artifacts are
 installed with pip hash checking, Git sources require a full resolved commit,
-mutable Poetry `file` and `directory` sources are rejected,
-NuGet Python downloads are verified against the SHA-512 hash in NuGet catalog metadata, and
+mutable Poetry `file` and `directory` sources are rejected, Python's complete
+Windows runtime is selected from the Python.org runtime index and verified against
+its published SHA-256, and
 ExeWrap is pinned to a versioned asset and SHA-256 digest. The installer manifest
 records this build-input provenance.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "app-builder"
-version = "1.3.1"
+version = "1.4.0"
 description = "Schema-first Windows application builder for Python-focused apps."
 readme = "README.md"
 requires-python = ">=3.11,<4.0"

--- a/test/test_build_preflight.py
+++ b/test/test_build_preflight.py
@@ -100,7 +100,7 @@ class TestBuildPreflight(unittest.TestCase):
                 validate_build_configuration(project_root, config, version="1.2.3")
 
     def test_config_loader_rejects_non_exact_python_version(self) -> None:
-        with self.assertRaisesRegex(ConfigError, "exact major.minor.patch"):
+        with self.assertRaisesRegex(ConfigError, "expected major.minor.patch"):
             load_app_builder_config(
                 {
                     "python_bundled": {"python_version": "3.12"},

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -189,6 +189,33 @@ installer:
   install_directory: "%localappdata%\\\\Demo"
 """)
 
+    def test_python_prerelease_selectors_are_supported(self) -> None:
+        for version in ("3.15.0b4", "3.15.0rc1", "3.15.0-beta", "3.15.0-rc.2"):
+            with self.subTest(version=version):
+                config = self._load_yaml(f"""
+python_bundled:
+  python_version: {version}
+installer:
+  name: Demo
+  install_directory: C:\\Demo
+""")
+                self.assertIsNotNone(config.python_bundled)
+                assert config.python_bundled is not None
+                self.assertEqual(version, config.python_bundled.python_version)
+
+    def test_invalid_python_release_selector_is_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ConfigError,
+            r"expected major\.minor\.patch",
+        ):
+            self._load_yaml("""
+python_bundled:
+  python_version: "3.15"
+installer:
+  name: Demo
+  install_directory: C:\\Demo
+""")
+
     def test_unknown_top_level_keys_are_rejected(self) -> None:
         with self.assertRaisesRegex(
             ConfigError,

--- a/test/test_python_runtime.py
+++ b/test/test_python_runtime.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import json
 import os
 import tempfile
@@ -16,39 +15,50 @@ from app_builder.main import main
 from app_builder.poetry_dependencies import DEV_GROUP, MAIN_GROUP, PoetryLock
 from app_builder.python_runtime import (
     EXE_WRAP_VERSION,
-    NuGetPythonPackage,
     PythonEnvironmentMaterializer,
+    PythonRuntimePackage,
     PythonVersionNotFoundError,
     _copy_bundled_runtime_support,
     _create_self_contained_venv,
     _download_cache_path,
     _exe_wrap_launcher_matches,
     _exe_wrap_python_config,
-    _extract_nuget_python_package,
+    _extract_python_runtime_package,
     _EXE_WRAP_DIGESTS,
     _EXE_WRAP_SOURCE_MARKER,
     _install_exe_wrap_python_launchers,
     _matches_version_pattern,
-    _load_nuget_python_digest,
-    _nuget_source_marker_matches,
-    _nuget_python_download_url,
+    _load_python_runtime_packages,
+    _python_source_marker_matches,
     _read_base_site_packages,
-    _select_nuget_python_version,
+    _select_python_runtime_version,
     _resolve_exe_wrap_package,
     _self_contained_venv_matches,
     _self_contained_venv_python_executable,
     _venv_matches_bundled_python,
-    _write_nuget_source_marker,
+    _write_python_source_marker,
     _write_base_site_packages,
     ensure_python_environments,
 )
 from app_builder.schema import PythonVenvOptions
 
-_TEST_NUGET_DIGEST = "sha512:" + "0" * 128
+_TEST_PYTHON_DIGEST = "sha256:" + "0" * 64
 
 
-def _nuget_payload_member(relative_path: str) -> str:
-    return "/".join(("tools", relative_path))
+def _write_fake_python_runtime(package: ZipFile) -> None:
+    for relative_path in (
+        "python.exe",
+        "pythonw.exe",
+        "python312.dll",
+        "Lib/os.py",
+        "Lib/ensurepip/__init__.py",
+        "Lib/venv/__init__.py",
+        "Lib/tkinter/__init__.py",
+        "DLLs/_tkinter.pyd",
+    ):
+        package.writestr(relative_path, relative_path)
+    package.writestr("Lib/site-packages/pip/__init__.py", "pip")
+    package.writestr("Scripts/pip.exe", "pip")
 
 
 def _write_fake_exe_wrap_package(package_path: Path) -> None:
@@ -57,113 +67,139 @@ def _write_fake_exe_wrap_package(package_path: Path) -> None:
         package.writestr("ExeWrap-windowed.exe", b"windowed-launcher")
 
 
-class TestNuGetPythonSelection(unittest.TestCase):
-    @patch("app_builder.python_runtime._load_nuget_json")
-    def test_reads_sha512_digest_from_registration_catalog_metadata(
-        self, load_json: object
+class TestPythonOrgRuntimeSelection(unittest.TestCase):
+    @patch(
+        "app_builder.python_runtime._python_runtime_architecture_tag", return_value="64"
+    )
+    @patch("app_builder.python_runtime._load_python_index_json")
+    def test_reads_python_core_runtime_and_digest_from_chained_index(
+        self, load_json: object, _architecture: object
     ) -> None:
-        digest_bytes = bytes(range(64))
         assert hasattr(load_json, "side_effect")
         load_json.side_effect = [
-            {"catalogEntry": "https://api.nuget.org/catalog/python.json"},
             {
-                "packageHashAlgorithm": "SHA512",
-                "packageHash": base64.b64encode(digest_bytes).decode("ascii"),
+                "versions": [
+                    {
+                        "company": "PythonCore",
+                        "id": "pythoncore-3.12-64",
+                        "tag": "3.12-64",
+                        "sort-version": "3.12.10",
+                        "url": "https://www.python.org/ftp/python/3.12.10/python-3.12.10-amd64.zip",
+                        "hash": {"sha256": "a" * 64},
+                    },
+                    {
+                        "company": "PythonEmbed",
+                        "id": "pythonembed-3.12-64",
+                        "tag": "3.12-64",
+                        "sort-version": "3.12.10",
+                        "url": "https://www.python.org/ftp/python/3.12.10/python-3.12.10-embeddable-amd64.zip",
+                        "hash": {"sha256": "b" * 64},
+                    },
+                ],
+                "next": "index-windows-recent.json",
             },
+            {"versions": []},
         ]
 
-        self.assertEqual(
-            "sha512:" + digest_bytes.hex(),
-            _load_nuget_python_digest("3.12.10"),
-        )
+        packages = _load_python_runtime_packages()
+
+        self.assertEqual(1, len(packages))
+        self.assertEqual("3.12.10", packages[0].version)
+        self.assertEqual("pythoncore-3.12-64", packages[0].runtime_id)
+        self.assertEqual("sha256:" + "a" * 64, packages[0].digest)
 
     def test_matches_prefix_and_wildcard_versions(self) -> None:
         self.assertTrue(_matches_version_pattern("3.12", "3.12.10"))
         self.assertTrue(_matches_version_pattern("3.12.*", "3.12.10"))
         self.assertTrue(_matches_version_pattern("3.12.10", "3.12.10.0"))
+        self.assertTrue(_matches_version_pattern("3.15.0-beta", "3.15.0b4"))
+        self.assertTrue(_matches_version_pattern("3.15.0-rc.2", "3.15.0rc2"))
         self.assertFalse(_matches_version_pattern("3.11", "3.12.10"))
 
-    def test_selects_latest_stable_matching_nuget_version(self) -> None:
+    def test_selects_latest_stable_matching_python_version(self) -> None:
         versions = [
             "3.12.9",
             "3.12.10",
-            "3.12.11-a1",
+            "3.12.11a1",
             "3.13.1",
         ]
 
         self.assertEqual(
             "3.12.10",
-            _select_nuget_python_version(versions, "3.12"),
+            _select_python_runtime_version(versions, "3.12"),
         )
 
-    def test_missing_nuget_version_error_suggests_same_minor_versions(self) -> None:
+    def test_selects_latest_matching_prerelease(self) -> None:
+        self.assertEqual(
+            "3.15.0b10",
+            _select_python_runtime_version(
+                ["3.15.0b4", "3.15.0b10", "3.15.0rc1"],
+                "3.15.0-beta",
+            ),
+        )
+
+    def test_missing_python_version_error_suggests_same_minor_versions(self) -> None:
         with self.assertRaises(PythonVersionNotFoundError) as error:
-            _select_nuget_python_version(
+            _select_python_runtime_version(
                 ["3.11.9", "3.12.9", "3.12.10", "3.13.1"],
                 "3.12.99",
             )
 
-        self.assertIn("NuGet package 'python'", str(error.exception))
+        self.assertIn("Python.org Windows runtime index", str(error.exception))
         self.assertIn("3.12.10", str(error.exception))
         self.assertIn("3.12.9", str(error.exception))
 
-    def test_nuget_download_url_uses_flat_container_package_layout(self) -> None:
-        self.assertEqual(
-            "https://api.nuget.org/v3-flatcontainer/python/3.12.10/python.3.12.10.nupkg",
-            _nuget_python_download_url("3.12.10"),
-        )
 
-
-class TestNuGetPythonExtraction(unittest.TestCase):
+class TestPythonOrgRuntimeExtraction(unittest.TestCase):
     def test_download_cache_path_uses_os_temp_download_cache(self) -> None:
         self.assertEqual(
             Path(
                 tempfile.gettempdir(),
                 "app-builder-downloads",
-                "python.3.12.10.nupkg",
+                "python-3.12.10-amd64.zip",
             ),
-            _download_cache_path(_nuget_python_download_url("3.12.10")),
+            _download_cache_path(
+                "https://www.python.org/ftp/python/3.12.10/python-3.12.10-amd64.zip"
+            ),
         )
 
-    def test_source_marker_records_nuget_package_origin(self) -> None:
+    def test_source_marker_records_python_org_package_origin(self) -> None:
         with TemporaryDirectory() as temp_dir_str:
             python_root = Path(temp_dir_str) / "bin" / "python"
             python_root.mkdir(parents=True)
 
-            _write_nuget_source_marker(
+            _write_python_source_marker(
                 python_root,
-                NuGetPythonPackage(
+                PythonRuntimePackage(
                     version="3.12.10",
-                    download_url=_nuget_python_download_url("3.12.10"),
-                    digest=_TEST_NUGET_DIGEST,
+                    runtime_id="pythoncore-3.12-64",
+                    download_url="https://www.python.org/ftp/python/3.12.10/python-3.12.10-amd64.zip",
+                    digest=_TEST_PYTHON_DIGEST,
                 ),
             )
 
-            self.assertTrue(_nuget_source_marker_matches(python_root, "3.12"))
-            self.assertTrue(_nuget_source_marker_matches(python_root, "3.12.10"))
-            self.assertFalse(_nuget_source_marker_matches(python_root, "3.11"))
+            self.assertTrue(_python_source_marker_matches(python_root, "3.12"))
+            self.assertTrue(_python_source_marker_matches(python_root, "3.12.10"))
+            self.assertFalse(_python_source_marker_matches(python_root, "3.11"))
 
-    def test_extracts_nuget_payload_into_bundled_python_layout(self) -> None:
+    def test_extracts_python_org_payload_into_bundled_python_layout(self) -> None:
         with TemporaryDirectory() as temp_dir_str:
             temp_dir = Path(temp_dir_str)
-            package_path = temp_dir / "python.3.12.10.nupkg"
+            package_path = temp_dir / "python-3.12.10-amd64.zip"
             python_root = temp_dir / "bin" / "python"
 
             with ZipFile(package_path, "w") as package:
-                package.writestr(_nuget_payload_member("python.exe"), "exe")
-                package.writestr(_nuget_payload_member("python312.dll"), "dll")
-                package.writestr(_nuget_payload_member("Lib/os.py"), "stdlib")
-                package.writestr(
-                    _nuget_payload_member("Lib/site-packages/pip/__init__.py"),
-                    "pip",
-                )
-                package.writestr("ignored.txt", "ignored")
+                _write_fake_python_runtime(package)
 
-            _extract_nuget_python_package(package_path, python_root)
+            _extract_python_runtime_package(package_path, python_root)
 
             self.assertTrue((python_root / "python" / "python.exe").exists())
             self.assertTrue((python_root / "python" / "python312.dll").exists())
             self.assertTrue((python_root / "python" / "Lib" / "os.py").exists())
+            self.assertTrue(
+                (python_root / "python" / "Lib" / "tkinter" / "__init__.py").exists()
+            )
+            self.assertTrue((python_root / "python" / "DLLs" / "_tkinter.pyd").exists())
             self.assertTrue(
                 (python_root / "Lib" / "site-packages" / "pip" / "__init__.py").exists()
             )
@@ -181,6 +217,21 @@ class TestNuGetPythonExtraction(unittest.TestCase):
                 "include-system-site-packages = false",
                 (python_root / "pyvenv.cfg").read_text(encoding="utf-8"),
             )
+
+    def test_rejects_python_runtime_archive_paths_outside_staging(self) -> None:
+        with TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            package_path = temp_dir / "python-malicious.zip"
+            python_root = temp_dir / "bin" / "python"
+            escaped_path = temp_dir / "escaped.txt"
+
+            with ZipFile(package_path, "w") as package:
+                package.writestr("../escaped.txt", "must not be written")
+
+            with self.assertRaisesRegex(RuntimeError, "unsafe archive path"):
+                _extract_python_runtime_package(package_path, python_root)
+
+            self.assertFalse(escaped_path.exists())
 
 
 class TestExeWrapPythonLaunchers(unittest.TestCase):
@@ -412,29 +463,22 @@ installer:
 
 
 class TestSelfContainedVenvSupport(unittest.TestCase):
-    def test_creates_self_contained_venv_from_nuget_python_layout(self) -> None:
+    def test_creates_self_contained_venv_from_python_org_layout(self) -> None:
         with TemporaryDirectory() as temp_dir_str:
             temp_dir = Path(temp_dir_str)
-            package_path = temp_dir / "python.3.12.10.nupkg"
+            package_path = temp_dir / "python-3.12.10-amd64.zip"
             venv_root = temp_dir / "venv"
             with ZipFile(package_path, "w") as package:
-                package.writestr(_nuget_payload_member("python.exe"), "exe")
-                package.writestr(_nuget_payload_member("pythonw.exe"), "exe")
-                package.writestr(_nuget_payload_member("python312.dll"), "dll")
-                package.writestr(_nuget_payload_member("Lib/os.py"), "stdlib")
-                package.writestr(
-                    _nuget_payload_member("Lib/site-packages/pip/__init__.py"),
-                    "pip",
-                )
-                package.writestr(_nuget_payload_member("Scripts/pip.exe"), "pip")
+                _write_fake_python_runtime(package)
 
             with (
                 patch(
-                    "app_builder.python_runtime._resolve_nuget_python_package",
-                    return_value=NuGetPythonPackage(
+                    "app_builder.python_runtime._resolve_python_runtime_package",
+                    return_value=PythonRuntimePackage(
                         version="3.12.10",
-                        download_url="https://example.invalid/python.3.12.10.nupkg",
-                        digest=_TEST_NUGET_DIGEST,
+                        runtime_id="pythoncore-3.12-64",
+                        download_url="https://example.invalid/python-3.12.10-amd64.zip",
+                        digest=_TEST_PYTHON_DIGEST,
                     ),
                 ),
                 patch(
@@ -472,7 +516,7 @@ class TestSelfContainedVenvSupport(unittest.TestCase):
                 "home =",
                 (venv_root / "pyvenv.cfg").read_text(encoding="utf-8"),
             )
-            self.assertTrue(_nuget_source_marker_matches(venv_root, "3.12"))
+            self.assertTrue(_python_source_marker_matches(venv_root, "3.12"))
             ensure_pip.assert_called_once_with(
                 _self_contained_venv_python_executable(venv_root)
             )
@@ -489,12 +533,13 @@ class TestSelfContainedVenvSupport(unittest.TestCase):
                 f"home = {(venv_root / 'python').resolve().as_posix()}\n",
                 encoding="utf-8",
             )
-            _write_nuget_source_marker(
+            _write_python_source_marker(
                 venv_root,
-                NuGetPythonPackage(
+                PythonRuntimePackage(
                     version="3.12.10",
-                    download_url="https://example.invalid/python.3.12.10.nupkg",
-                    digest=_TEST_NUGET_DIGEST,
+                    runtime_id="pythoncore-3.12-64",
+                    download_url="https://example.invalid/python-3.12.10-amd64.zip",
+                    digest=_TEST_PYTHON_DIGEST,
                 ),
             )
             (venv_root / "Scripts" / "python.exe").write_bytes(


### PR DESCRIPTION
## What changed

- replace the NuGet Python package with Python.org's complete Windows runtime
- select x64, x86, or ARM64 packages from Python.org's official runtime index
- verify every runtime against the SHA-256 published in that index
- ship matching Tkinter/Tcl/Tk, `venv`, `ensurepip`, headers, and import libraries by default
- support exact Python prereleases and release-level selectors such as `3.15.0-beta`
- preserve app-builder's relocatable `bin/python` layout, dependency placement, ExeWrap launchers, cache, and provenance manifest
- update the generated template, configuration reference, HTML help, pipeline docs, and release audits
- bump the package version to 1.4.0

## Why

The NuGet runtime was intentionally minimal. Projects needing Tkinter had to graft a separately downloaded Tcl/Tk MSI onto that runtime, couple the graft to an exact CPython version, and maintain extra lifecycle code. Python.org now publishes complete, extractable Windows runtimes with a machine-readable index and SHA-256 digests. Using that source gives each configured Python version its own matching standard-library and native runtime components as one coherent package.

## Validation

- 196 app-builder tests passed; 2 platform-condition tests skipped
- Black clean across `app_builder` and `test`
- MyPy clean across 46 source files
- live Python.org index resolved `3.11.1`, `3.12.10`, and `3.15.0-beta`
- live 3.12.10 runtime digest matched Python.org
- real raw and ExeWrap-launched probes both reported Python 3.12.10 and Tcl/Tk 8.6.15
- real self-contained runtime successfully imported `tkinter`, `venv`, and `ensurepip`
- malicious ZIP traversal regression is rejected before extraction