### PR TITLE
Package inherited Start Menu icons

### DIFF
--- a/app_builder/assets/app_builder_template.yaml
+++ b/app_builder/assets/app_builder_template.yaml
@@ -51,10 +51,10 @@ installer:
   # it is not a drive root or protected Windows directory.
   install_directory: '%LOCALAPPDATA%\MyCompany\MyApp'
 
-  # Optional string. Project-relative .ico file embedded into generated executables. It is
-  # also the default install-relative Start Menu icon path, so include it at the same
-  # payload path or override the shortcut icon. Default if omitted: application-
-  # templates/icon.ico.
+  # Optional, nullable string | null. Optional project-relative .ico file embedded into
+  # generated executables. Start Menu shortcuts with no icon inherit it, and app-builder
+  # includes it in the payload automatically at its normal or remapped destination.
+  # Default if omitted: null.
   icon: application-templates/icon.ico
 
   # Optional string. Inner payload archive format. Use zip for the Windows tar.exe path or
@@ -76,7 +76,7 @@ installer:
   start_menu:
     - target: application-templates/program.cmd
       display_name: MyApp
-      icon: application-templates/icon.ico
+      icon: null
 
   # Optional mapping. Early installer hook command declarations. Default if omitted:
   # BootstrapHooks defaults.

--- a/app_builder/build.py
+++ b/app_builder/build.py
@@ -128,6 +128,14 @@ def build_release(
         )
         if not config.installer.paths.include_dist:
             included_files = _exclude_payload_directory(included_files, dist_dir)
+        if _shortcut_inherits_installer_icon(config, installer_icon_path):
+            assert installer_icon_path is not None
+            included_files = _include_payload_file(included_files, installer_icon_path)
+            reporter.detail(
+                "Implicit payload input: "
+                f"{installer_icon_path.resolve().relative_to(project_root.resolve())} "
+                "(inherited Start Menu icon)"
+            )
         remap_table = build_remap_table(
             project_root, included_files, config.installer.paths.remap
         )
@@ -141,9 +149,11 @@ def build_release(
         installer_bundled_python_path = _installer_bundled_python_path(
             project_root, config, remap_table
         )
+        start_menu = _start_menu_manifest(config, remap_table, installer_icon_path)
         _validate_installer_payload_contract(
             config,
             remap_table,
+            start_menu=start_menu,
             hook_python_candidates=installer_hook_python_candidates,
         )
         reporter.detail(f"Resolved {len(remap_table)} payload files:")
@@ -176,14 +186,7 @@ def build_release(
             "payload_archive": payload_archive.name,
             "hook_python_candidates": installer_hook_python_candidates,
             "python_bundled_path": installer_bundled_python_path,
-            "start_menu": [
-                {
-                    "target": item.target,
-                    "display_name": item.display_name,
-                    "icon": item.icon or config.installer.icon,
-                }
-                for item in config.installer.start_menu
-            ],
+            "start_menu": start_menu,
             "install_hooks": {
                 "pre_install": config.installer.install_hooks.pre_install,
                 "post_install": config.installer.install_hooks.post_install,
@@ -473,15 +476,61 @@ def _resolve_installer_icon(
     project_root: Path,
     config: AppBuilderConfig,
 ) -> Path | None:
-    icon = config.installer.icon.strip()
-    if not icon:
+    configured_icon = config.installer.icon
+    if configured_icon is None or not configured_icon.strip():
         return None
-    icon_path = project_root / icon
+    icon = Path(configured_icon)
+    if icon.is_absolute() or ".." in icon.parts:
+        raise ValueError("installer.icon must be a project-relative file path.")
+    icon_path = (project_root / icon).resolve()
+    try:
+        icon_path.relative_to(project_root.resolve())
+    except ValueError as error:
+        raise ValueError("installer.icon must resolve inside the project.") from error
     if icon_path.is_file():
         return icon_path
-    if icon == "application-templates/icon.ico":
-        return None
     raise FileNotFoundError(f"Configured installer.icon does not exist: {icon_path}")
+
+
+def _shortcut_inherits_installer_icon(
+    config: AppBuilderConfig,
+    installer_icon_path: Path | None,
+) -> bool:
+    return installer_icon_path is not None and any(
+        shortcut.icon is None for shortcut in config.installer.start_menu
+    )
+
+
+def _include_payload_file(files: list[Path], required_file: Path) -> list[Path]:
+    resolved_required = required_file.resolve()
+    if any(file_path.resolve() == resolved_required for file_path in files):
+        return files
+    return [*files, resolved_required]
+
+
+def _start_menu_manifest(
+    config: AppBuilderConfig,
+    remap_table: Mapping[Path, PurePosixPath],
+    installer_icon_path: Path | None,
+) -> list[dict[str, str | None]]:
+    inherited_icon: str | None = None
+    if _shortcut_inherits_installer_icon(config, installer_icon_path):
+        assert installer_icon_path is not None
+        destination = remap_table.get(installer_icon_path.resolve())
+        if destination is None:
+            raise RuntimeError(
+                "The inherited installer icon was not included in the payload."
+            )
+        inherited_icon = destination.as_posix()
+
+    return [
+        {
+            "target": shortcut.target,
+            "display_name": shortcut.display_name,
+            "icon": inherited_icon if shortcut.icon is None else shortcut.icon or None,
+        }
+        for shortcut in config.installer.start_menu
+    ]
 
 
 def _exclude_payload_directory(files: list[Path], directory: Path) -> list[Path]:
@@ -569,6 +618,7 @@ def _validate_installer_payload_contract(
     config: AppBuilderConfig,
     remap_table: Mapping[Path, PurePosixPath],
     *,
+    start_menu: list[dict[str, str | None]],
     hook_python_candidates: list[str],
 ) -> None:
     destinations = {
@@ -588,12 +638,14 @@ def _validate_installer_payload_contract(
                 f"{value!r}."
             )
 
-    for index, shortcut in enumerate(config.installer.start_menu):
+    for index, (shortcut, manifest_shortcut) in enumerate(
+        zip(config.installer.start_menu, start_menu)
+    ):
         require_payload_path(
             shortcut.target,
             label=f"installer.start_menu[{index}].target",
         )
-        effective_icon = shortcut.icon or config.installer.icon
+        effective_icon = manifest_shortcut["icon"]
         if effective_icon:
             require_payload_path(
                 effective_icon,

--- a/app_builder/schema.py
+++ b/app_builder/schema.py
@@ -113,7 +113,7 @@ class StartMenuShortcut:
     )
     icon: str | None = config_field(
         default=None,
-        description="Optional install-relative shortcut icon path. The icon must be present at that payload path after remapping; when omitted, installer.icon is used.",
+        description="Optional install-relative shortcut icon path. When omitted or null, the shortcut inherits installer.icon; use an empty string to leave IconLocation unset. Explicit icon paths must be present in the payload after remapping.",
         example="application-templates/icon.ico",
     )
 
@@ -128,9 +128,9 @@ class InstallerOptions:
         description="Windows install directory. A variable-root path must start with %LOCALAPPDATA%, %APPDATA%, or %USERPROFILE% and name an application subdirectory; the installer expands it on the user's machine. A fixed absolute path is also allowed when it is not a drive root or protected Windows directory.",
         example=r"%LOCALAPPDATA%\MyCompany\MyApp",
     )
-    icon: str = config_field(
-        default="application-templates/icon.ico",
-        description="Project-relative .ico file embedded into generated executables. It is also the default install-relative Start Menu icon path, so include it at the same payload path or override the shortcut icon.",
+    icon: str | None = config_field(
+        default=None,
+        description="Optional project-relative .ico file embedded into generated executables. Start Menu shortcuts with no icon inherit it, and app-builder includes it in the payload automatically at its normal or remapped destination.",
         example="application-templates/icon.ico",
     )
     payload_format: str = config_field(
@@ -155,7 +155,7 @@ class InstallerOptions:
             {
                 "target": "application-templates/program.cmd",
                 "display_name": "MyApp",
-                "icon": "application-templates/icon.ico",
+                "icon": None,
             }
         ],
     )

--- a/docs/app-builder-help.html
+++ b/docs/app-builder-help.html
@@ -386,10 +386,10 @@ installer:
   # it is not a drive root or protected Windows directory.
   install_directory: &#x27;%LOCALAPPDATA%\MyCompany\MyApp&#x27;
 
-  # Optional string. Project-relative .ico file embedded into generated executables. It is
-  # also the default install-relative Start Menu icon path, so include it at the same
-  # payload path or override the shortcut icon. Default if omitted: application-
-  # templates/icon.ico.
+  # Optional, nullable string | null. Optional project-relative .ico file embedded into
+  # generated executables. Start Menu shortcuts with no icon inherit it, and app-builder
+  # includes it in the payload automatically at its normal or remapped destination.
+  # Default if omitted: null.
   icon: application-templates/icon.ico
 
   # Optional string. Inner payload archive format. Use zip for the Windows tar.exe path or
@@ -411,7 +411,7 @@ installer:
   start_menu:
     - target: application-templates/program.cmd
       display_name: MyApp
-      icon: application-templates/icon.ico
+      icon: null
 
   # Optional mapping. Early installer hook command declarations. Default if omitted:
   # BootstrapHooks defaults.
@@ -722,11 +722,11 @@ publications:
             </tr>
             <tr>
               <td><code>icon</code></td>
-              <td><code>string</code></td>
+              <td><code>string | null</code></td>
               <td>no</td>
+              <td><code>null</code></td>
               <td><code>application-templates/icon.ico</code></td>
-              <td><code>application-templates/icon.ico</code></td>
-              <td>Project-relative .ico file embedded into generated executables. It is also the default install-relative Start Menu icon path, so include it at the same payload path or override the shortcut icon.</td>
+              <td>Optional project-relative .ico file embedded into generated executables. Start Menu shortcuts with no icon inherit it, and app-builder includes it in the payload automatically at its normal or remapped destination.</td>
             </tr>
             <tr>
               <td><code>payload_format</code></td>
@@ -757,7 +757,7 @@ publications:
               <td><code>list[mapping]</code></td>
               <td>no</td>
               <td><code>[]</code></td>
-              <td><code>[{target: application-templates/program.cmd, display_name: MyApp, icon: application-templates/icon.ico}]</code></td>
+              <td><code>[{target: application-templates/program.cmd, display_name: MyApp, icon: null}]</code></td>
               <td>Windows Start Menu shortcut declarations.</td>
             </tr>
             <tr>
@@ -829,7 +829,7 @@ publications:
               <td>no</td>
               <td><code>null</code></td>
               <td><code>application-templates/icon.ico</code></td>
-              <td>Optional install-relative shortcut icon path. The icon must be present at that payload path after remapping; when omitted, installer.icon is used.</td>
+              <td>Optional install-relative shortcut icon path. When omitted or null, the shortcut inherits installer.icon; use an empty string to leave IconLocation unset. Explicit icon paths must be present in the payload after remapping.</td>
             </tr>
           </tbody>
         </table>
@@ -1464,6 +1464,13 @@ publications:
           resolve to real final payload paths after remapping.
         </p>
         <p>
+          <code>installer.icon</code> is optional. When configured, it is embedded into generated executables.
+          A Start Menu shortcut with an omitted or null <code>icon</code> inherits it, and app-builder includes
+          the icon automatically at its normal project-relative path or configured remap. With no installer
+          icon, or with an empty shortcut <code>icon</code>, <code>IconLocation</code> is left unset so Windows
+          uses the target executable or file-type icon.
+        </p>
+        <p>
           The installer extracts its outer ZIP layer to a random temp directory, runs the PowerShell installer,
           forwards all command-line arguments, and removes its temp extraction directory when finished. If an
           environment blocks running the exe, the manual fallback is: rename the installer to <code>.zip</code>,
@@ -1670,7 +1677,6 @@ installer:
       - README.md
       - src
       - "build/generated/${APP.VERSION}"
-      - app.ico
       - bin/python
     exclude:
       - build/generated/*.tmp

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,10 +62,10 @@ installer:
   # it is not a drive root or protected Windows directory.
   install_directory: '%LOCALAPPDATA%\MyCompany\MyApp'
 
-  # Optional string. Project-relative .ico file embedded into generated executables. It is
-  # also the default install-relative Start Menu icon path, so include it at the same
-  # payload path or override the shortcut icon. Default if omitted: application-
-  # templates/icon.ico.
+  # Optional, nullable string | null. Optional project-relative .ico file embedded into
+  # generated executables. Start Menu shortcuts with no icon inherit it, and app-builder
+  # includes it in the payload automatically at its normal or remapped destination.
+  # Default if omitted: null.
   icon: application-templates/icon.ico
 
   # Optional string. Inner payload archive format. Use zip for the Windows tar.exe path or
@@ -87,7 +87,7 @@ installer:
   start_menu:
     - target: application-templates/program.cmd
       display_name: MyApp
-      icon: application-templates/icon.ico
+      icon: null
 
   # Optional mapping. Early installer hook command declarations. Default if omitted:
   # BootstrapHooks defaults.
@@ -286,11 +286,11 @@ installer:
 | --- | --- | --- | --- | --- | --- |
 | `name` | `string` | yes | required | `MyApp` | Human-facing application name and Windows install identity. It must be a trimmed, filename-safe, non-reserved Windows name. |
 | `install_directory` | `string` | yes | required | `'%LOCALAPPDATA%\MyCompany\MyApp'` | Windows install directory. A variable-root path must start with %LOCALAPPDATA%, %APPDATA%, or %USERPROFILE% and name an application subdirectory; the installer expands it on the user's machine. A fixed absolute path is also allowed when it is not a drive root or protected Windows directory. |
-| `icon` | `string` | no | `application-templates/icon.ico` | `application-templates/icon.ico` | Project-relative .ico file embedded into generated executables. It is also the default install-relative Start Menu icon path, so include it at the same payload path or override the shortcut icon. |
+| `icon` | `string \| null` | no | `null` | `application-templates/icon.ico` | Optional project-relative .ico file embedded into generated executables. Start Menu shortcuts with no icon inherit it, and app-builder includes it in the payload automatically at its normal or remapped destination. |
 | `payload_format` | `string` | no | `zip` | `zip` | Inner payload archive format. Use zip for the Windows tar.exe path or 7z for stronger compression with bundled 7-Zip extraction. |
 | `wait_on_exit` | `boolean` | no | `true` | `true` | Whether generated installer scripts should wait briefly before exiting. The wait closes after 30 seconds or Enter; --yes skips prompts and the wait, while --no-wait skips only the wait. |
 | `add_uninstaller` | `boolean` | no | `true` | `true` | Whether installation adds the installed uninstall scripts, Start Menu uninstall shortcut, and per-user Windows Installed Apps registration. |
-| `start_menu` | `list[mapping]` | no | `[]` | `[{target: application-templates/program.cmd, display_name: MyApp, icon: application-templates/icon.ico}]` | Windows Start Menu shortcut declarations. |
+| `start_menu` | `list[mapping]` | no | `[]` | `[{target: application-templates/program.cmd, display_name: MyApp, icon: null}]` | Windows Start Menu shortcut declarations. |
 | `bootstrap_hooks` | `mapping` | no | `see nested defaults` |  | Early installer hook command declarations. |
 | `install_hooks` | `mapping` | no | `see nested defaults` |  | Installer and uninstaller hook command declarations. |
 | `dist` | `string` | no | `dist` | `dist` | Project-relative subdirectory inside the project where release artifacts and build logs are written. |
@@ -302,7 +302,7 @@ installer:
 | --- | --- | --- | --- | --- | --- |
 | `target` | `string` | yes | required | `application-templates/program.cmd` | Install-relative command or file launched by the shortcut. The target must be present at that payload path after remapping. |
 | `display_name` | `string \| null` | no | `null` | `MyApp` | Shortcut display name. Defaults to the installer name when omitted by downstream tooling. |
-| `icon` | `string \| null` | no | `null` | `application-templates/icon.ico` | Optional install-relative shortcut icon path. The icon must be present at that payload path after remapping; when omitted, installer.icon is used. |
+| `icon` | `string \| null` | no | `null` | `application-templates/icon.ico` | Optional install-relative shortcut icon path. When omitted or null, the shortcut inherits installer.icon; use an empty string to leave IconLocation unset. Explicit icon paths must be present in the payload after remapping. |
 
 ## `config.installer.bootstrap_hooks`
 

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -238,7 +238,9 @@ If a `post_uninstall` entrypoint points inside the install directory, it must be
 
 ## 11. Icons
 
-`installer.icon` is the single icon setting. app-builder uses it for generated executables and as the default Start Menu shortcut icon when a shortcut does not specify its own icon.
+`installer.icon` is optional. When configured, app-builder embeds it into generated executables. A Start Menu shortcut whose `icon` is omitted or `null` inherits that icon. app-builder automatically adds the inherited icon to the payload at its normal project-relative destination or its configured remap, and records that installed destination in the manifest.
+
+When `installer.icon` is omitted, app-builder leaves the shortcut's `IconLocation` unset and Windows uses the target executable or file-type icon. Set a shortcut's `icon` to an empty string to request the same Windows fallback even when the installer has an icon. A nonempty shortcut `icon` is an explicit install-relative payload path and must already exist after remapping.
 
 For app-builder's dogfood build, the same icon is embedded into the generated payload `app-builder.exe`.
 

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -758,9 +758,12 @@ build_hooks: {{}}
                 / "Sevenzip Demo.lnk"
             )
             self.assertTrue(shortcut_path.is_file())
-            self.assertEqual(
-                str(install_dir / "app.ico").casefold(),
-                _shortcut_icon_location(shortcut_path).split(",", 1)[0].casefold(),
+            shortcut_icon_path = Path(
+                _shortcut_icon_location(shortcut_path).split(",", 1)[0]
+            )
+            self.assertTrue(shortcut_icon_path.is_file())
+            self.assertTrue(
+                os.path.samefile(install_dir / "app.ico", shortcut_icon_path)
             )
 
             subprocess.run(

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -31,6 +31,26 @@ def _sha256_bytes(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
+def _shortcut_icon_location(shortcut_path: Path) -> str:
+    env = os.environ.copy()
+    env["APP_BUILDER_TEST_SHORTCUT"] = str(shortcut_path)
+    completed = subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-Command",
+            "$Shell = New-Object -ComObject WScript.Shell; "
+            "$Shortcut = $Shell.CreateShortcut($env:APP_BUILDER_TEST_SHORTCUT); "
+            "[Console]::Out.Write([string]$Shortcut.IconLocation)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return completed.stdout
+
+
 class TestEndToEndBuild(unittest.TestCase):
     def test_build_collects_and_selects_multiple_release_assets(self) -> None:
         with TemporaryDirectory() as temp_dir_str:
@@ -203,12 +223,142 @@ build_hooks: {}
                 build_release(project_root, version="1.0.0")
 
             config_path.write_text(
-                config_path.read_text(encoding="utf-8")
-                .replace('icon: ""', "icon: unused.ico")
-                .replace("target: missing.cmd", "target: app.cmd"),
+                config_path.read_text(encoding="utf-8").replace(
+                    "    - target: missing.cmd",
+                    "    - target: app.cmd\n      icon: unused.ico",
+                ),
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(FileNotFoundError, r"start_menu\[0\].icon"):
+                build_release(project_root, version="1.0.0")
+
+    def test_inherited_installer_icon_is_implicitly_included_and_remapped(
+        self,
+    ) -> None:
+        cases = (
+            ("", "app.ico"),
+            (
+                "    remap:\n      - [app.ico, resources/application.ico]",
+                "resources/application.ico",
+            ),
+        )
+        for remap, expected_icon in cases:
+            with (
+                self.subTest(expected_icon=expected_icon),
+                TemporaryDirectory() as temp_dir_str,
+            ):
+                project_root = Path(temp_dir_str)
+                subprocess.run(
+                    ["git", "init"],
+                    cwd=project_root,
+                    check=True,
+                    capture_output=True,
+                )
+                (project_root / "app.cmd").write_text("@echo off\n", encoding="utf-8")
+                _write_sample_icon(project_root / "app.ico")
+                (project_root / "app_builder.yaml").write_text(
+                    f"""
+app_builder_version: current
+python_bundled: null
+python_venv: null
+installer:
+  name: Implicit Icon
+  install_directory: '%localappdata%\\ImplicitIcon'
+  icon: app.ico
+  paths:
+    include: [app.cmd]
+{remap}
+  start_menu:
+    - target: app.cmd
+build_hooks: {{}}
+""".strip(),
+                    encoding="utf-8",
+                )
+
+                release = build_release(project_root, version="1.0.0")
+                manifest = json.loads(release.manifest_path.read_text(encoding="utf-8"))
+                with ZipFile(release.payload_archive) as payload_zip:
+                    payload_names = payload_zip.namelist()
+
+                self.assertEqual(expected_icon, manifest["start_menu"][0]["icon"])
+                self.assertEqual(1, payload_names.count(expected_icon))
+                self.assertIn(expected_icon, manifest["included_files"])
+
+    def test_shortcut_can_use_windows_fallback_or_opt_out_of_inheritance(self) -> None:
+        cases = (
+            ("null", ""),
+            ("app.ico", '      icon: ""'),
+        )
+        for installer_icon, shortcut_icon in cases:
+            with (
+                self.subTest(installer_icon=installer_icon),
+                TemporaryDirectory() as temp_dir_str,
+            ):
+                project_root = Path(temp_dir_str)
+                subprocess.run(
+                    ["git", "init"],
+                    cwd=project_root,
+                    check=True,
+                    capture_output=True,
+                )
+                (project_root / "app.cmd").write_text("@echo off\n", encoding="utf-8")
+                _write_sample_icon(project_root / "app.ico")
+                (project_root / "app_builder.yaml").write_text(
+                    f"""
+app_builder_version: current
+python_bundled: null
+python_venv: null
+installer:
+  name: Icon Fallback
+  install_directory: '%localappdata%\\IconFallback'
+  icon: {installer_icon}
+  paths:
+    include: [app.cmd]
+  start_menu:
+    - target: app.cmd
+{shortcut_icon}
+build_hooks: {{}}
+""".strip(),
+                    encoding="utf-8",
+                )
+
+                release = build_release(project_root, version="1.0.0")
+                manifest = json.loads(release.manifest_path.read_text(encoding="utf-8"))
+                with ZipFile(release.payload_archive) as payload_zip:
+                    payload_names = payload_zip.namelist()
+
+                self.assertIsNone(manifest["start_menu"][0]["icon"])
+                self.assertNotIn("app.ico", payload_names)
+
+    def test_implicit_installer_icon_still_obeys_payload_collision_checks(self) -> None:
+        with TemporaryDirectory() as temp_dir_str:
+            project_root = Path(temp_dir_str)
+            subprocess.run(
+                ["git", "init"], cwd=project_root, check=True, capture_output=True
+            )
+            (project_root / "app.cmd").write_text("@echo off\n", encoding="utf-8")
+            _write_sample_icon(project_root / "app.ico")
+            (project_root / "app_builder.yaml").write_text(
+                """
+app_builder_version: current
+python_bundled: null
+python_venv: null
+installer:
+  name: Icon Collision
+  install_directory: '%localappdata%\\IconCollision'
+  icon: app.ico
+  paths:
+    include: [app.cmd]
+    remap:
+      - [app.ico, app.cmd]
+  start_menu:
+    - target: app.cmd
+build_hooks: {}
+""".strip(),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "Archive destination collision"):
                 build_release(project_root, version="1.0.0")
 
     def test_build_excludes_dist_unless_explicitly_included(self) -> None:
@@ -484,7 +634,6 @@ installer:
   paths:
     include:
       - app.cmd
-      - app.ico
   start_menu:
     - target: app.cmd
       display_name: Icon Demo
@@ -497,9 +646,12 @@ build_hooks: {}
             manifest = json.loads(release.manifest_path.read_text(encoding="utf-8"))
             expected_group = _render_icon_group_resource(_read_icon_images(icon_path))
             installer_bytes = release.installer_archive.read_bytes()
+            with ZipFile(release.payload_archive) as payload_zip:
+                payload_names = payload_zip.namelist()
 
         self.assertEqual("app.ico", manifest["start_menu"][0]["icon"])
         self.assertIn(expected_group, installer_bytes)
+        self.assertIn("app.ico", payload_names)
 
     @unittest.skipIf(os.name != "nt", "7z installer execution targets Windows")
     def test_build_release_with_7z_payload_installs_and_uninstalls(self) -> None:
@@ -515,6 +667,7 @@ build_hooks: {}
             (project_root / "app.cmd").write_text(
                 "@echo off\necho hello\n", encoding="utf-8"
             )
+            _write_sample_icon(project_root / "app.ico")
             (project_root / "hooks").mkdir()
             (project_root / "hooks" / "post-install.cmd").write_text(
                 "@echo off\n"
@@ -530,6 +683,7 @@ python_venv: null
 installer:
   name: Sevenzip Demo
   install_directory: "{escaped_install_dir}"
+  icon: app.ico
   payload_format: 7z
   wait_on_exit: false
   dist: dist
@@ -542,6 +696,9 @@ installer:
   install_hooks:
     post_install:
       - [hooks/post-install.cmd]
+  start_menu:
+    - target: bin/app.cmd
+      display_name: Sevenzip Demo
 build_hooks: {{}}
 """.strip(),
                 encoding="utf-8",
@@ -582,6 +739,20 @@ build_hooks: {{}}
             self.assertEqual(
                 "post-install",
                 (install_dir / "post-install.txt").read_text(encoding="utf-8").strip(),
+            )
+            shortcut_path = (
+                appdata_dir
+                / "Microsoft"
+                / "Windows"
+                / "Start Menu"
+                / "Programs"
+                / "Sevenzip Demo"
+                / "Sevenzip Demo.lnk"
+            )
+            self.assertTrue(shortcut_path.is_file())
+            self.assertEqual(
+                str(install_dir / "app.ico").casefold(),
+                _shortcut_icon_location(shortcut_path).split(",", 1)[0].casefold(),
             )
 
             subprocess.run(

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -275,7 +275,11 @@ build_hooks: {{}}
                     encoding="utf-8",
                 )
 
-                release = build_release(project_root, version="1.0.0")
+                with patch(
+                    "app_builder.installer_bundle.stamp_exe_icon",
+                    side_effect=lambda launcher, _icon: launcher,
+                ):
+                    release = build_release(project_root, version="1.0.0")
                 manifest = json.loads(release.manifest_path.read_text(encoding="utf-8"))
                 with ZipFile(release.payload_archive) as payload_zip:
                     payload_names = payload_zip.namelist()
@@ -322,7 +326,11 @@ build_hooks: {{}}
                     encoding="utf-8",
                 )
 
-                release = build_release(project_root, version="1.0.0")
+                with patch(
+                    "app_builder.installer_bundle.stamp_exe_icon",
+                    side_effect=lambda launcher, _icon: launcher,
+                ):
+                    release = build_release(project_root, version="1.0.0")
                 manifest = json.loads(release.manifest_path.read_text(encoding="utf-8"))
                 with ZipFile(release.payload_archive) as payload_zip:
                     payload_names = payload_zip.namelist()


### PR DESCRIPTION
## What changed

- make `installer.icon` genuinely optional instead of defaulting to a placeholder path
- automatically include a configured installer icon when a Start Menu shortcut inherits it
- preserve the icon's normal payload path or configured remap and write that installed destination to the manifest
- allow an empty per-shortcut `icon` to leave Windows `IconLocation` unset
- keep explicit shortcut icons as ordinary install-relative payload paths
- update the generated template, config reference, packaged HTML help, and release pipeline documentation

## Why

A shortcut with no explicit icon already inherited `installer.icon` in the manifest, but app-builder did not ensure that file was installed. This could silently leave Windows using the target file type's icon, and remapped installer icons were referenced by their stale source path.

The implementation uses the existing payload/remap pipeline rather than creating UUID or hash directories. That gives the icon a stable, project-owned path across upgrades while retaining the normal collision protections.

## Validation

- `python -m unittest discover -s test`: 206 tests passed
- Windows 7-Zip installer test installs the generated application and verifies the real `.lnk` `IconLocation` through `WScript.Shell`
- `python -m black --fast --check .`
- `python -m mypy .`

Fixes #24