### PR TITLE
Document end-user app-builder installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,33 @@
 
 Full user help is available in [docs/app-builder-help.html](docs/app-builder-help.html). `app-builder --help` prints a link to that same file.
 
-## Quick Start
+## Install app-builder
 
-Install app-builder while developing:
+1. Download the latest `app-builder-<version>-installer.exe` from
+   [GitHub Releases](https://github.com/AutoActuary/app-builder/releases/latest).
+2. Run the installer. It installs app-builder for the current Windows user and
+   adds the installation directory to the front of the user `PATH`.
+3. Open a new terminal and verify the installation:
+
+```text
+app-builder --version
+app-builder --help
+```
+
+Run a newer installer to upgrade an existing app-builder installation. To
+remove it, use **Windows Settings > Apps > Installed apps > app-builder**. The
+uninstaller also removes app-builder from the user `PATH`.
+
+### Source development
+
+An editable Python installation is for contributors working on app-builder
+itself; it is not the normal user installation:
 
 ```text
 python -m pip install -e .
 ```
+
+## Quick Start
 
 Create starter config inside a git repository:
 

--- a/docs/app-builder-help.html
+++ b/docs/app-builder-help.html
@@ -157,6 +157,7 @@
     <nav aria-label="Chapters">
       <h1>app-builder Help</h1>
       <a href="#overview">Overview</a>
+      <a href="#install-app-builder">Install app-builder</a>
       <a href="#quick-start">Quick Start</a>
       <a href="#mental-model">Project To Installation</a>
       <a href="#commands">Commands</a>
@@ -186,6 +187,35 @@
           The 1.x line is intentionally Python-focused. Features from old <code>bin/...</code> toolchains are
           retired except for Python. Non-Python tools still fit naturally through explicit build hooks.
         </p>
+      </section>
+
+      <section id="install-app-builder">
+        <h2>Install app-builder</h2>
+        <ol>
+          <li>
+            Download the latest <code>app-builder-&lt;version&gt;-installer.exe</code> from
+            <a href="https://github.com/AutoActuary/app-builder/releases/latest">GitHub Releases</a>.
+          </li>
+          <li>
+            Run the installer. It installs app-builder for the current Windows user and adds the installation
+            directory to the front of the user <code>PATH</code>.
+          </li>
+          <li>Open a new terminal and verify the installation:</li>
+        </ol>
+        <pre><code>app-builder --version
+app-builder --help</code></pre>
+        <p>
+          Run a newer installer to upgrade an existing app-builder installation. To remove it, open
+          <strong>Windows Settings &gt; Apps &gt; Installed apps</strong>, select <strong>app-builder</strong>, and
+          choose <strong>Uninstall</strong>. The uninstaller also removes app-builder from the user
+          <code>PATH</code>.
+        </p>
+        <h3>Source development</h3>
+        <p>
+          Contributors working on app-builder itself can install the checkout as an editable Python package.
+          This is a development setup, not the normal user installation.
+        </p>
+        <pre><code>python -m pip install -e .</code></pre>
       </section>
 
       <section id="quick-start">


### PR DESCRIPTION
## Summary

- document the released Windows installer as the normal way users obtain app-builder
- explain PATH registration, verification, upgrades, and Windows Installed Apps removal
- move editable `pip install -e .` guidance into an explicitly development-only section
- add the same user-first installation path to the packaged offline HTML help

## Existing documentation contract

This completes the original user-documentation issue alongside the documentation already present in 1.x:

- the packaged, navigable offline HTML guide opened by `app-builder --help`
- the schema-generated and snapshot-tested complete configuration reference
- documented commands, interpolation variables, payload mappings, Python runtimes, hook ordering, installer and uninstaller behavior, releases, examples, and troubleshooting
- a focused README quick start and detailed release-pipeline reference
- wheel packaging and tests for the installed help document

A hosted documentation website may still be useful later, but it is a separate publishing enhancement rather than missing user documentation.

## Validation

- `python -m unittest test.test_cli_help test.test_template`
- `git diff --check`
- standard-library HTML parser smoke check

Closes #23