### PR TITLE
Make reusable cache locations configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,26 @@ app-builder init [--force]
 app-builder python
 app-builder deps
 app-builder lock
+app-builder cache path
+app-builder cache info
 app-builder versions list
 app-builder versions remove <ref>
 app-builder release [--version <version>] [--verbose]
 app-builder release-gh [--version <version>] [--draft | --no-draft] [--verbose]
 app-builder 0.x <legacy-command>
 ```
+
+## Reusable Caches
+
+app-builder keeps managed versions and reusable Python and ExeWrap downloads in
+the user cache. Set `APP_BUILDER_CACHE_ROOT` for a stable CI cache directory.
+When that variable is set, app-builder also places pip and Poetry caches below
+the same root unless their standard `PIP_CACHE_DIR` or `POETRY_CACHE_DIR`
+variables are already set. Use `app-builder cache path` for the machine-readable
+root and `app-builder cache info` to inspect the complete effective layout.
+
+Cache placement is machine policy and is intentionally not part of
+`app_builder.yaml`.
 
 ## Documentation
 

--- a/app_builder/main.py
+++ b/app_builder/main.py
@@ -13,6 +13,7 @@ if __name__ == "__main__" and not __package__:
     runpy.run_module("app_builder", run_name="__main__")
     raise SystemExit(0)
 
+from app_builder_meta.environment import get_environment
 from app_builder_meta.version_cache import (
     default_cache_root,
     managed_version_manifests,
@@ -60,6 +61,8 @@ def main() -> None:
     Build and package Windows-first Python applications.
     """
 
+    get_environment()
+
 
 @main.command()
 @click.option(
@@ -97,6 +100,44 @@ def lock_cmd() -> None:
     poetry_lock = refresh_poetry_lock(project_root)
     click.echo(f"Refreshed lock: {poetry_lock.path}")
     click.echo(f"SHA-256: {poetry_lock.sha256}")
+
+
+@main.group("cache")
+def cache_cmd() -> None:
+    """Inspect the effective reusable cache locations."""
+
+
+@cache_cmd.command("path")
+def cache_path_cmd() -> None:
+    """Print the app-builder cache root for scripts and CI configuration."""
+
+    click.echo(get_environment().cache_root)
+
+
+@cache_cmd.command("info")
+def cache_info_cmd() -> None:
+    """Show app-builder and delegated tool cache locations."""
+
+    environment = get_environment()
+    click.echo(f"Root: {environment.cache_root}")
+    click.echo(f"Downloads: {environment.downloads}")
+    click.echo(f"Managed versions: {environment.versions}")
+    click.echo(
+        "pip: "
+        + (
+            str(environment.pip_cache_dir)
+            if environment.pip_cache_dir
+            else "pip default"
+        )
+    )
+    click.echo(
+        "Poetry: "
+        + (
+            str(environment.poetry_cache_dir)
+            if environment.poetry_cache_dir
+            else "Poetry default"
+        )
+    )
 
 
 @main.group("versions")

--- a/app_builder/poetry_dependencies.py
+++ b/app_builder/poetry_dependencies.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import os
 import re
 import subprocess
 import sys
@@ -11,6 +10,8 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from app_builder_meta.environment import get_environment
 
 MAIN_GROUP = "main"
 DEV_GROUP = "dev"
@@ -104,7 +105,7 @@ def refresh_poetry_lock(project_root: Path) -> PoetryLock:
 def _run_poetry_lock_command(
     project_root: Path, args: list[str], *, action: str
 ) -> None:
-    env = os.environ.copy()
+    env = get_environment().subprocess_environment()
     env["POETRY_VIRTUALENVS_CREATE"] = "false"
     env["POETRY_NO_INTERACTION"] = "1"
     completed = subprocess.run(
@@ -177,6 +178,7 @@ def install_locked_poetry_dependencies(
             direct_requirements.append(requirement)
 
     if hashed_lines:
+        subprocess_env = get_environment().subprocess_environment()
         with tempfile.TemporaryDirectory() as temp_dir_str:
             requirements_path = Path(temp_dir_str) / "locked-requirements.txt"
             requirements_path.write_text(
@@ -186,12 +188,13 @@ def install_locked_poetry_dependencies(
             command.extend(
                 ["--require-hashes", "--requirement", str(requirements_path)]
             )
-            subprocess.run(command, check=True)
+            subprocess.run(command, env=subprocess_env, check=True)
 
+    subprocess_env = get_environment().subprocess_environment()
     for requirement_chunk in _chunks(direct_requirements, _PIP_INSTALL_CHUNK_SIZE):
         command = _pip_install_command(python_executable, index_urls)
         command.extend(requirement_chunk)
-        subprocess.run(command, check=True)
+        subprocess.run(command, env=subprocess_env, check=True)
 
 
 def _pip_install_command(

--- a/app_builder/python_runtime.py
+++ b/app_builder/python_runtime.py
@@ -12,11 +12,15 @@ import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from zipfile import ZipFile
+
+from app_builder_meta.cache_lock import exclusive_cache_lock
+from app_builder_meta.environment import get_environment
 
 from .config import load_project_config
 from .poetry_dependencies import (
@@ -400,10 +404,7 @@ def _download_file(url: str, destination: Path) -> None:
 
 
 def _download_cache_path(url: str) -> Path:
-    filename = Path(urllib.parse.urlsplit(url).path).name
-    if not filename:
-        filename = "download"
-    return Path(tempfile.gettempdir(), "app-builder-downloads", filename)
+    return get_environment().download_path(url)
 
 
 def _sha256_file(path: Path) -> str:
@@ -437,20 +438,36 @@ def _file_digest(path: Path, algorithm: str) -> str:
 
 
 def _ensure_downloaded_file(url: str, digest: str | None = None) -> Path:
-    path = _download_cache_path(url)
+    environment = get_environment()
+    path = environment.download_path(url)
     expected = _expected_digest(digest)
-    if (
-        path.exists()
-        and expected is not None
-        and _file_digest(path, expected[0]) != expected[1]
-    ):
-        path.unlink()
-    if not path.exists():
-        _download_file(url, path)
-    if expected is not None and _file_digest(path, expected[0]) != expected[1]:
-        raise RuntimeError(
-            f"Downloaded file {path} did not match expected {expected[0]} digest."
+    with exclusive_cache_lock(environment.download_lock_path(url)):
+        if (
+            path.exists()
+            and expected is not None
+            and _file_digest(path, expected[0]) != expected[1]
+        ):
+            path.unlink()
+        if path.exists():
+            return path
+
+        temporary_path = path.with_name(
+            f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
         )
+        try:
+            _download_file(url, temporary_path)
+            if (
+                expected is not None
+                and _file_digest(temporary_path, expected[0]) != expected[1]
+            ):
+                raise RuntimeError(
+                    f"Downloaded file {url} did not match expected "
+                    f"{expected[0]} digest."
+                )
+            path.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(temporary_path, path)
+        finally:
+            temporary_path.unlink(missing_ok=True)
     return path
 
 

--- a/app_builder_meta/cache_lock.py
+++ b/app_builder_meta/cache_lock.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import BinaryIO, Iterator
+
+if sys.platform == "win32":
+    import msvcrt
+
+    def _acquire_platform_lock(lock_file: BinaryIO) -> None:
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+
+    def _release_platform_lock(lock_file: BinaryIO) -> None:
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+
+else:
+    import fcntl
+
+    def _acquire_platform_lock(lock_file: BinaryIO) -> None:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _release_platform_lock(lock_file: BinaryIO) -> None:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def exclusive_cache_lock(
+    lock_path: Path, *, timeout_seconds: float = 600.0
+) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        lock_file.seek(0, os.SEEK_END)
+        if lock_file.tell() == 0:
+            lock_file.write(b"\0")
+            lock_file.flush()
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            lock_file.seek(0)
+            try:
+                _acquire_platform_lock(lock_file)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Timed out waiting for app-builder cache lock: {lock_path}"
+                    )
+                time.sleep(0.1)
+        try:
+            yield
+        finally:
+            lock_file.seek(0)
+            _release_platform_lock(lock_file)

--- a/app_builder_meta/dispatch.py
+++ b/app_builder_meta/dispatch.py
@@ -12,6 +12,7 @@ from .config_probe import (
     probe_project_config,
 )
 from .legacy_0x import run_legacy_bridge
+from .environment import get_environment
 from .version_cache import default_install_root, run_managed_version
 
 
@@ -57,6 +58,7 @@ class MetaDispatchError(RuntimeError):
 def dispatch(argv: list[str], *, cwd: Path | None = None) -> int:
     active_cwd = (cwd or Path.cwd()).resolve()
     try:
+        get_environment()
         target = choose_target(argv, active_cwd)
         return run_target(target, cwd=active_cwd)
     except (ConfigProbeError, MetaDispatchError, RuntimeError) as error:

--- a/app_builder_meta/environment.py
+++ b/app_builder_meta/environment.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import difflib
+import hashlib
+import os
+import sys
+import urllib.parse
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+
+_SETTING_VARIABLES = frozenset(
+    {
+        "APP_BUILDER_CACHE_ROOT",
+        "APP_BUILDER_INSTALL_ROOT",
+    }
+)
+
+# These values are supplied to hooks. They remain valid when a hook invokes
+# app-builder recursively, including on case-insensitive Windows environments.
+_CONTEXT_VARIABLES = frozenset(
+    {
+        "APP_BUILDER_INSTALL_DIRECTORY",
+        "APP_BUILDER_NAME",
+        "APP_BUILDER_PROJECT_ROOT",
+        "APP_BUILDER_START_MENU",
+        "APP_BUILDER_VERSION",
+    }
+)
+
+KNOWN_APP_BUILDER_ENVIRONMENT_VARIABLES = _SETTING_VARIABLES | _CONTEXT_VARIABLES
+
+
+@dataclass(frozen=True, slots=True)
+class AppBuilderEnvironment:
+    cache_root: Path
+    install_root: Path
+    pip_cache_dir: Path | None
+    poetry_cache_dir: Path | None
+    cache_root_is_explicit: bool = False
+    install_root_is_explicit: bool = False
+
+    @property
+    def downloads(self) -> Path:
+        return self.cache_root / "downloads"
+
+    @property
+    def versions(self) -> Path:
+        return self.cache_root / "versions"
+
+    @property
+    def locks(self) -> Path:
+        return self.cache_root / "locks"
+
+    def download_path(self, url: str) -> Path:
+        parsed = urllib.parse.urlsplit(url)
+        filename = Path(parsed.path).name or "download"
+        key = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+        return self.downloads / key / filename
+
+    def download_lock_path(self, url: str) -> Path:
+        key = hashlib.sha256(url.encode("utf-8")).hexdigest()
+        return self.locks / "downloads" / f"{key}.lock"
+
+    def subprocess_environment(
+        self, environ: Mapping[str, str] | None = None
+    ) -> dict[str, str]:
+        result = dict(os.environ if environ is None else environ)
+        if self.cache_root_is_explicit:
+            result["APP_BUILDER_CACHE_ROOT"] = str(self.cache_root)
+        if self.install_root_is_explicit:
+            result["APP_BUILDER_INSTALL_ROOT"] = str(self.install_root)
+        if self.pip_cache_dir is not None:
+            result["PIP_CACHE_DIR"] = str(self.pip_cache_dir)
+        if self.poetry_cache_dir is not None:
+            result["POETRY_CACHE_DIR"] = str(self.poetry_cache_dir)
+        return result
+
+
+def _environment_value(environ: Mapping[str, str], name: str) -> str | None:
+    direct = environ.get(name)
+    if direct is not None:
+        return direct
+    folded_name = name.casefold()
+    for key, value in environ.items():
+        if key.casefold() == folded_name:
+            return value
+    return None
+
+
+def _configured_path(environ: Mapping[str, str], name: str) -> Path | None:
+    value = _environment_value(environ, name)
+    if value is None or not value.strip():
+        return None
+    return Path(value).expanduser().resolve()
+
+
+def _default_cache_root(environ: Mapping[str, str]) -> Path:
+    if os.name == "nt":
+        local_app_data = _environment_value(environ, "LOCALAPPDATA")
+        if local_app_data:
+            return (Path(local_app_data) / "app-builder" / "cache").resolve()
+    xdg_cache = _environment_value(environ, "XDG_CACHE_HOME")
+    base = Path(xdg_cache).expanduser() if xdg_cache else Path.home() / ".cache"
+    return (base / "app-builder").resolve()
+
+
+def _emit_warning(message: str) -> None:
+    print(f"Warning: {message}", file=sys.stderr)
+
+
+def _warn_for_unknown_variables(
+    environ: Mapping[str, str], warning_sink: Callable[[str], None]
+) -> None:
+    seen: set[str] = set()
+    for raw_name in environ:
+        name = raw_name.upper()
+        if not name.startswith("APP_BUILDER_") or name in seen:
+            continue
+        seen.add(name)
+        if name in KNOWN_APP_BUILDER_ENVIRONMENT_VARIABLES:
+            continue
+        suggestion = difflib.get_close_matches(
+            name,
+            sorted(KNOWN_APP_BUILDER_ENVIRONMENT_VARIABLES),
+            n=1,
+            cutoff=0.72,
+        )
+        suffix = f" Did you mean {suggestion[0]}?" if suggestion else ""
+        warning_sink(f"unknown app-builder environment variable {raw_name}.{suffix}")
+
+
+def _read_environment(
+    environ: Mapping[str, str],
+    *,
+    warning_sink: Callable[[str], None] = _emit_warning,
+) -> AppBuilderEnvironment:
+    _warn_for_unknown_variables(environ, warning_sink)
+
+    configured_cache_root = _configured_path(environ, "APP_BUILDER_CACHE_ROOT")
+    configured_install_root = _configured_path(environ, "APP_BUILDER_INSTALL_ROOT")
+    cache_root = configured_cache_root or _default_cache_root(environ)
+    install_root = configured_install_root or Path(__file__).resolve().parents[1]
+
+    pip_cache_dir = _configured_path(environ, "PIP_CACHE_DIR")
+    poetry_cache_dir = _configured_path(environ, "POETRY_CACHE_DIR")
+    if configured_cache_root is not None:
+        pip_cache_dir = pip_cache_dir or cache_root / "pip"
+        poetry_cache_dir = poetry_cache_dir or cache_root / "poetry"
+
+    return AppBuilderEnvironment(
+        cache_root=cache_root,
+        install_root=install_root,
+        pip_cache_dir=pip_cache_dir,
+        poetry_cache_dir=poetry_cache_dir,
+        cache_root_is_explicit=configured_cache_root is not None,
+        install_root_is_explicit=configured_install_root is not None,
+    )
+
+
+@cache
+def get_environment() -> AppBuilderEnvironment:
+    return _read_environment(os.environ)

--- a/app_builder_meta/version_cache.py
+++ b/app_builder_meta/version_cache.py
@@ -8,32 +8,13 @@ import shutil
 import stat
 import subprocess
 import sys
-import time
 import uuid
-from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import BinaryIO, Iterator
 
-if sys.platform == "win32":
-    import msvcrt
-
-    def _acquire_platform_lock(lock_file: BinaryIO) -> None:
-        msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
-
-    def _release_platform_lock(lock_file: BinaryIO) -> None:
-        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
-
-else:
-    import fcntl
-
-    def _acquire_platform_lock(lock_file: BinaryIO) -> None:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-
-    def _release_platform_lock(lock_file: BinaryIO) -> None:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-
+from .cache_lock import exclusive_cache_lock as _exclusive_cache_lock
+from .environment import get_environment
 
 APP_BUILDER_REPOSITORY_URL = "https://github.com/AutoActuary/app-builder.git"
 
@@ -48,28 +29,16 @@ class ManagedVersion:
 
 
 def default_install_root() -> Path:
-    override = os.environ.get("APP_BUILDER_INSTALL_ROOT")
-    if override:
-        return Path(override).resolve()
-    return Path(__file__).resolve().parents[1]
+    return get_environment().install_root
 
 
 def default_cache_root() -> Path:
-    override = os.environ.get("APP_BUILDER_CACHE_ROOT")
-    if override:
-        return Path(override).expanduser().resolve()
-    if os.name == "nt":
-        local_app_data = os.environ.get("LOCALAPPDATA")
-        if local_app_data:
-            return (Path(local_app_data) / "app-builder" / "cache").resolve()
-    xdg_cache = os.environ.get("XDG_CACHE_HOME")
-    base = Path(xdg_cache).expanduser() if xdg_cache else Path.home() / ".cache"
-    return (base / "app-builder").resolve()
+    return get_environment().cache_root
 
 
 def run_managed_version(ref: str, argv: list[str], *, cwd: Path) -> int:
     managed = ensure_managed_version(ref)
-    env = os.environ.copy()
+    env = get_environment().subprocess_environment()
     env["PYTHONNOUSERSITE"] = "1"
     env["PYTHONPATH"] = _prepend_path(str(managed.repo_path), env.get("PYTHONPATH", ""))
     completed = subprocess.run(
@@ -139,8 +108,15 @@ def ensure_managed_version(
             base_python = python_executable or Path(sys.executable)
             _run([str(base_python), "-m", "venv", str(staging_venv)])
             staging_python = _venv_python(staging_venv)
-            _run([str(staging_python), "-m", "pip", "install", "--upgrade", "pip"])
-            _run([str(staging_python), "-m", "pip", "install", str(staging_repo)])
+            subprocess_env = get_environment().subprocess_environment()
+            _run(
+                [str(staging_python), "-m", "pip", "install", "--upgrade", "pip"],
+                env=subprocess_env,
+            )
+            _run(
+                [str(staging_python), "-m", "pip", "install", str(staging_repo)],
+                env=subprocess_env,
+            )
 
             final_repo = managed_root / "repo"
             final_venv = managed_root / "venv"
@@ -321,35 +297,6 @@ def _venv_python(venv_root: Path) -> Path:
     return venv_root / "bin" / "python"
 
 
-@contextmanager
-def _exclusive_cache_lock(
-    lock_path: Path, *, timeout_seconds: float = 600.0
-) -> Iterator[None]:
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a+b") as lock_file:
-        lock_file.seek(0, os.SEEK_END)
-        if lock_file.tell() == 0:
-            lock_file.write(b"\0")
-            lock_file.flush()
-        deadline = time.monotonic() + timeout_seconds
-        while True:
-            lock_file.seek(0)
-            try:
-                _acquire_platform_lock(lock_file)
-                break
-            except OSError:
-                if time.monotonic() >= deadline:
-                    raise TimeoutError(
-                        f"Timed out waiting for app-builder cache lock: {lock_path}"
-                    )
-                time.sleep(0.1)
-        try:
-            yield
-        finally:
-            lock_file.seek(0)
-            _release_platform_lock(lock_file)
-
-
 def _prepend_path(value: str, existing: str) -> str:
     if not existing:
         return value
@@ -362,10 +309,12 @@ def _run(
     cwd: Path | None = None,
     capture: bool = False,
     check: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
+        env=env,
         check=check,
         capture_output=capture,
         text=True,

--- a/docs/app-builder-help.html
+++ b/docs/app-builder-help.html
@@ -169,6 +169,7 @@
       <a href="#installer">Installer</a>
       <a href="#uninstall">Uninstall</a>
       <a href="#releases">Releases</a>
+      <a href="#caching">Reusable Caches</a>
       <a href="#versions">app-builder Versions</a>
       <a href="#legacy">Legacy Projects</a>
       <a href="#examples">Example Configs</a>
@@ -320,6 +321,10 @@ Release files in dist
             <tr>
               <td><code>app-builder lock</code></td>
               <td>Explicitly creates or refreshes <code>poetry.lock</code>; normal builds only verify it.</td>
+            </tr>
+            <tr>
+              <td><code>app-builder cache path | info</code></td>
+              <td>Prints the machine-readable cache root or explains all effective app-builder, pip, and Poetry cache locations.</td>
             </tr>
             <tr>
               <td><code>app-builder versions list | remove &lt;ref&gt;</code></td>
@@ -1635,6 +1640,45 @@ gh auth login</code></pre>
         </p>
       </section>
 
+      <section id="caching">
+        <h2>Reusable Caches</h2>
+        <p>
+          app-builder caches reusable Python and ExeWrap archives and managed app-builder versions. On Windows the
+          root defaults to <code>%LOCALAPPDATA%\app-builder\cache</code>; on other platforms it follows
+          <code>XDG_CACHE_HOME</code> and then <code>~/.cache/app-builder</code>. Cache placement is machine policy,
+          not part of the application release contract, so it is intentionally not an <code>app_builder.yaml</code>
+          setting.
+        </p>
+        <p>
+          Set <code>APP_BUILDER_CACHE_ROOT</code> when CI needs one stable directory to restore. Explicit
+          <code>PIP_CACHE_DIR</code> and <code>POETRY_CACHE_DIR</code> values retain control of those tools. Otherwise,
+          when the app-builder root is explicitly set, its pip and Poetry subprocesses use
+          <code>&lt;root&gt;/pip</code> and <code>&lt;root&gt;/poetry</code>. Without an explicit app-builder root, pip and
+          Poetry keep their native defaults.
+        </p>
+        <pre><code>env:
+  APP_BUILDER_CACHE_ROOT: ${{ runner.temp }}/app-builder-cache
+
+steps:
+  - uses: actions/cache@v4
+    with:
+      path: ${{ env.APP_BUILDER_CACHE_ROOT }}
+      key: app-builder-v1-${{ runner.os }}-${{ hashFiles('poetry.lock', 'app_builder.yaml') }}
+      restore-keys: |
+        app-builder-v1-${{ runner.os }}-</code></pre>
+        <p>
+          Downloads are separated by URL-derived keys, written to private temporary siblings, digest-checked when a
+          digest is published, and atomically promoted under a cross-process lock. Failed downloads cannot poison a
+          later build. Use <code>app-builder cache path</code> for scripts and <code>app-builder cache info</code> to
+          inspect the resolved layout.
+        </p>
+        <p>
+          App-builder-owned settings use the <code>APP_BUILDER_</code> namespace. Unknown names produce one warning,
+          with a spelling suggestion where possible, and their values are never printed. Set environment variables
+          before the first app-builder command in a process.
+        </p>
+      </section>
+
       <section id="versions">
         <h2>app-builder Versions</h2>
         <p>
@@ -1654,8 +1698,7 @@ gh auth login</code></pre>
           </tbody>
         </table>
         <p>
-          Managed versions are cached under <code>%LOCALAPPDATA%\app-builder\cache</code>, or the path supplied by
-          <code>APP_BUILDER_CACHE_ROOT</code>. Cache keys include the source URL and requested ref. A branch is
+          Managed versions are cached under the common app-builder cache root. Cache keys include the source URL and requested ref. A branch is
           refreshed when its remote commit changes; a moved cached tag is refused. Cache creation is locked per
           ref, built privately, and atomically promoted, so concurrent commands cannot consume a partial cache. Use
           <code>app-builder versions list</code> to inspect manifests and

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -302,7 +302,49 @@ normal build remains readable. Every run writes a timestamped diagnostic log to
 output sizes and hashes, and the final publication selection. `--verbose` also
 prints those details to the terminal.
 
-## 14. Managed App-Builder Versions
+## 14. Reusable Build Caches
+
+Reusable downloads and managed app-builder versions use a user-local cache. On
+Windows the root defaults to `%LOCALAPPDATA%\app-builder\cache`; on other
+platforms it follows `XDG_CACHE_HOME` and then `~/.cache/app-builder`. Set
+`APP_BUILDER_CACHE_ROOT` to make the complete app-builder cache tree explicit,
+especially in CI. This is machine policy rather than project release behavior,
+so it is not an `app_builder.yaml` setting.
+
+The configured root contains content-keyed Python and ExeWrap archives under
+`downloads`, managed app-builder checkouts under `versions`, and cache locks
+under `locks`. Downloads use URL-derived keys so unrelated assets with the same
+filename cannot collide. A download is written privately, digest-checked when a
+digest is published, and atomically promoted while holding a cross-process lock.
+A failed or partial download never becomes a cache hit.
+
+When `APP_BUILDER_CACHE_ROOT` is explicitly set, app-builder supplies
+`<root>/pip` and `<root>/poetry` to its pip and Poetry subprocesses. Explicit
+standard `PIP_CACHE_DIR` and `POETRY_CACHE_DIR` values take precedence. When the
+app-builder root is not explicitly set, pip and Poetry retain their own native
+cache defaults.
+
+Use `app-builder cache path` for the resolved root and `app-builder cache info`
+for all effective locations. A GitHub Actions job can persist the complete tree:
+
+```yaml
+env:
+  APP_BUILDER_CACHE_ROOT: ${{ runner.temp }}/app-builder-cache
+
+steps:
+  - uses: actions/cache@v4
+    with:
+      path: ${{ env.APP_BUILDER_CACHE_ROOT }}
+      key: app-builder-v1-${{ runner.os }}-${{ hashFiles('poetry.lock', 'app_builder.yaml') }}
+      restore-keys: |
+        app-builder-v1-${{ runner.os }}-
+```
+
+All app-builder-owned settings use the `APP_BUILDER_` namespace. An unknown
+name produces a warning with a likely spelling correction; values are never
+printed. Set cache variables before the first app-builder command in a process.
+
+## 15. Managed App-Builder Versions
 
 An explicit 1.x `app_builder_version` ref is resolved from the app-builder Git
 repository into the user cache at `%LOCALAPPDATA%\app-builder\cache` (or
@@ -317,7 +359,7 @@ and manifest are complete.
 Use `app-builder versions list` to inspect the cache and
 `app-builder versions remove <ref>` for deliberate eviction.
 
-## 15. Release Owner Checklist
+## 16. Release Owner Checklist
 
 1. When dependencies changed, run `app-builder lock` deliberately and commit both
    `pyproject.toml` and `poetry.lock`.

--- a/test/test_app_builder_meta.py
+++ b/test/test_app_builder_meta.py
@@ -9,6 +9,9 @@ from tempfile import TemporaryDirectory
 from typing import Any
 from unittest.mock import patch
 
+from app_builder_meta.cache_lock import exclusive_cache_lock
+from app_builder_meta.environment import get_environment
+
 from app_builder_meta.config_probe import ConfigProbeError, read_plain_yaml_version
 from app_builder_meta.dispatch import (
     CurrentInstall,
@@ -24,7 +27,6 @@ from app_builder_meta.legacy_0x import bridge_executable, run_legacy_bridge
 from app_builder_meta.version_cache import (
     ManagedVersion,
     _cache_key,
-    _exclusive_cache_lock,
     _resolve_source_ref,
     default_cache_root,
     managed_version_manifests,
@@ -134,6 +136,9 @@ class TestAppBuilderMetaDispatch(unittest.TestCase):
 
 
 class TestAppBuilderMetaExecutionAdapters(unittest.TestCase):
+    def tearDown(self) -> None:
+        get_environment.cache_clear()
+
     def test_legacy_bridge_uses_import_safe_directory_name(self) -> None:
         install_root = Path("C:/app-builder")
 
@@ -197,6 +202,7 @@ class TestAppBuilderMetaExecutionAdapters(unittest.TestCase):
             with patch.dict(
                 "os.environ", {"APP_BUILDER_CACHE_ROOT": temp_dir_str}, clear=False
             ):
+                get_environment.cache_clear()
                 self.assertEqual(Path(temp_dir_str).resolve(), default_cache_root())
 
     def test_resolves_tags_as_immutable_and_branches_at_current_remote_head(
@@ -266,9 +272,9 @@ class TestAppBuilderMetaExecutionAdapters(unittest.TestCase):
     def test_managed_cache_lock_rejects_concurrent_writer(self) -> None:
         with TemporaryDirectory() as temp_dir_str:
             lock_path = Path(temp_dir_str) / "versions" / ".locks" / "demo.lock"
-            with _exclusive_cache_lock(lock_path):
+            with exclusive_cache_lock(lock_path):
                 with self.assertRaisesRegex(TimeoutError, "cache lock"):
-                    with _exclusive_cache_lock(lock_path, timeout_seconds=0.05):
+                    with exclusive_cache_lock(lock_path, timeout_seconds=0.05):
                         self.fail("concurrent cache writer unexpectedly acquired lock")
 
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from app_builder.main import main
+from app_builder_meta.environment import (
+    AppBuilderEnvironment,
+    _read_environment,
+    get_environment,
+)
+
+
+class TestAppBuilderEnvironment(unittest.TestCase):
+    def tearDown(self) -> None:
+        get_environment.cache_clear()
+
+    def test_explicit_root_derives_tool_caches_and_preserves_overrides(self) -> None:
+        warnings: list[str] = []
+        with TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            environment = _read_environment(
+                {
+                    "APP_BUILDER_CACHE_ROOT": str(temp_dir / "shared"),
+                    "APP_BUILDER_INSTALL_ROOT": str(temp_dir / "install"),
+                    "PIP_CACHE_DIR": str(temp_dir / "custom-pip"),
+                },
+                warning_sink=warnings.append,
+            )
+
+            self.assertEqual((temp_dir / "shared").resolve(), environment.cache_root)
+            self.assertEqual(
+                (temp_dir / "custom-pip").resolve(), environment.pip_cache_dir
+            )
+            self.assertEqual(
+                (temp_dir / "shared" / "poetry").resolve(),
+                environment.poetry_cache_dir,
+            )
+            self.assertEqual((temp_dir / "install").resolve(), environment.install_root)
+            subprocess_environment = environment.subprocess_environment(
+                {"PATH": "test-path"}
+            )
+
+        self.assertEqual([], warnings)
+        self.assertEqual("test-path", subprocess_environment["PATH"])
+        self.assertEqual(
+            str(environment.cache_root),
+            subprocess_environment["APP_BUILDER_CACHE_ROOT"],
+        )
+        self.assertEqual(
+            str(environment.pip_cache_dir),
+            subprocess_environment["PIP_CACHE_DIR"],
+        )
+        self.assertEqual(
+            str(environment.poetry_cache_dir),
+            subprocess_environment["POETRY_CACHE_DIR"],
+        )
+
+    def test_default_root_leaves_pip_and_poetry_on_native_defaults(self) -> None:
+        environment = _read_environment({}, warning_sink=lambda _message: None)
+
+        self.assertFalse(environment.cache_root_is_explicit)
+        self.assertIsNone(environment.pip_cache_dir)
+        self.assertIsNone(environment.poetry_cache_dir)
+
+    def test_unknown_app_builder_variable_warns_with_suggestion(self) -> None:
+        warnings: list[str] = []
+
+        _read_environment(
+            {
+                "APP_BUILDER_CAHCE_ROOT": "C:/misspelled",
+                "app_builder_name": "hook context",
+            },
+            warning_sink=warnings.append,
+        )
+
+        self.assertEqual(1, len(warnings))
+        self.assertIn("APP_BUILDER_CAHCE_ROOT", warnings[0])
+        self.assertIn("APP_BUILDER_CACHE_ROOT", warnings[0])
+
+    def test_get_environment_is_lazy_and_cached(self) -> None:
+        with TemporaryDirectory() as temp_dir_str:
+            get_environment.cache_clear()
+            with patch.dict(
+                os.environ,
+                {"APP_BUILDER_CACHE_ROOT": temp_dir_str},
+                clear=False,
+            ):
+                first = get_environment()
+                second = get_environment()
+
+        self.assertIs(first, second)
+        self.assertEqual(Path(temp_dir_str).resolve(), first.cache_root)
+
+    def test_download_keys_separate_equal_filenames_from_different_urls(self) -> None:
+        environment = AppBuilderEnvironment(
+            cache_root=Path("C:/cache"),
+            install_root=Path("C:/app-builder"),
+            pip_cache_dir=None,
+            poetry_cache_dir=None,
+        )
+
+        first = environment.download_path("https://one.invalid/files/runtime.zip")
+        second = environment.download_path("https://two.invalid/files/runtime.zip")
+
+        self.assertNotEqual(first, second)
+        self.assertEqual("runtime.zip", first.name)
+        self.assertEqual("runtime.zip", second.name)
+
+    def test_cache_commands_report_the_resolved_contract(self) -> None:
+        with TemporaryDirectory() as temp_dir_str:
+            cache_root = Path(temp_dir_str) / "cache"
+            environment = AppBuilderEnvironment(
+                cache_root=cache_root,
+                install_root=Path(temp_dir_str) / "app-builder",
+                pip_cache_dir=cache_root / "pip",
+                poetry_cache_dir=cache_root / "poetry",
+            )
+            runner = CliRunner()
+            with patch("app_builder.main.get_environment", return_value=environment):
+                path_result = runner.invoke(main, ["cache", "path"])
+                info_result = runner.invoke(main, ["cache", "info"])
+
+        self.assertEqual(0, path_result.exit_code, path_result.output)
+        self.assertEqual(str(cache_root), path_result.output.strip())
+        self.assertEqual(0, info_result.exit_code, info_result.output)
+        self.assertIn(f"Downloads: {cache_root / 'downloads'}", info_result.output)
+        self.assertIn(f"pip: {cache_root / 'pip'}", info_result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_poetry_dependencies.py
+++ b/test/test_poetry_dependencies.py
@@ -17,6 +17,7 @@ from app_builder.poetry_dependencies import (
     load_poetry_lock,
     refresh_poetry_lock,
 )
+from app_builder_meta.environment import AppBuilderEnvironment
 
 
 class TestPoetryDependencies(unittest.TestCase):
@@ -153,15 +154,32 @@ groups = ["main"]
 
         requirement_text = ""
 
-        def capture_run(command: list[str], *, check: bool) -> None:
+        captured_environment: dict[str, str] = {}
+
+        def capture_run(
+            command: list[str], *, env: dict[str, str], check: bool
+        ) -> None:
             nonlocal requirement_text
             requirement_path = Path(command[command.index("--requirement") + 1])
             requirement_text = requirement_path.read_text(encoding="utf-8")
+            captured_environment.update(env)
 
-        with patch(
-            "app_builder.poetry_dependencies.subprocess.run",
-            side_effect=capture_run,
-        ) as run:
+        environment = AppBuilderEnvironment(
+            cache_root=Path("C:/cache"),
+            install_root=Path("C:/app-builder"),
+            pip_cache_dir=Path("C:/custom-pip"),
+            poetry_cache_dir=Path("C:/custom-poetry"),
+        )
+        with (
+            patch(
+                "app_builder.poetry_dependencies.subprocess.run",
+                side_effect=capture_run,
+            ) as run,
+            patch(
+                "app_builder.poetry_dependencies.get_environment",
+                return_value=environment,
+            ),
+        ):
             install_locked_poetry_dependencies(
                 project_root=project_root,
                 python_executable=python_executable,
@@ -178,6 +196,9 @@ groups = ["main"]
         self.assertIn("--hash=sha256:" + "b" * 64, requirement_text)
         self.assertIn(" \\\n    --hash=sha256:", requirement_text)
         self.assertNotIn("\n+", requirement_text)
+        self.assertEqual(
+            str(environment.pip_cache_dir), captured_environment["PIP_CACHE_DIR"]
+        )
 
     def test_missing_lock_tells_user_to_refresh_explicitly(self) -> None:
         with TemporaryDirectory() as temp_dir_str:

--- a/test/test_python_runtime.py
+++ b/test/test_python_runtime.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
-import tempfile
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -21,6 +21,7 @@ from app_builder.python_runtime import (
     _copy_bundled_runtime_support,
     _create_self_contained_venv,
     _download_cache_path,
+    _ensure_downloaded_file,
     _exe_wrap_launcher_matches,
     _exe_wrap_python_config,
     _extract_python_runtime_package,
@@ -41,6 +42,7 @@ from app_builder.python_runtime import (
     ensure_python_environments,
 )
 from app_builder.schema import PythonVenvOptions
+from app_builder_meta.environment import AppBuilderEnvironment
 
 _TEST_PYTHON_DIGEST = "sha256:" + "0" * 64
 
@@ -151,17 +153,129 @@ class TestPythonOrgRuntimeSelection(unittest.TestCase):
 
 
 class TestPythonOrgRuntimeExtraction(unittest.TestCase):
-    def test_download_cache_path_uses_os_temp_download_cache(self) -> None:
-        self.assertEqual(
-            Path(
-                tempfile.gettempdir(),
-                "app-builder-downloads",
-                "python-3.12.10-amd64.zip",
-            ),
-            _download_cache_path(
-                "https://www.python.org/ftp/python/3.12.10/python-3.12.10-amd64.zip"
-            ),
+    def test_download_cache_path_uses_configured_content_keyed_cache(self) -> None:
+        url = "https://www.python.org/ftp/python/3.12.10/python-3.12.10-amd64.zip"
+        cache_root = Path("cache").resolve()
+        environment = AppBuilderEnvironment(
+            cache_root=cache_root,
+            install_root=Path("app-builder").resolve(),
+            pip_cache_dir=None,
+            poetry_cache_dir=None,
         )
+        with patch(
+            "app_builder.python_runtime.get_environment", return_value=environment
+        ):
+            path = _download_cache_path(url)
+
+        self.assertEqual(
+            cache_root
+            / "downloads"
+            / hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+            / "python-3.12.10-amd64.zip",
+            path,
+        )
+
+    def test_download_cache_hit_avoids_network_and_promotion_is_atomic(self) -> None:
+        with TemporaryDirectory() as temp_dir_str:
+            payload = b"complete archive"
+            digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+            environment = AppBuilderEnvironment(
+                cache_root=Path(temp_dir_str),
+                install_root=Path(temp_dir_str),
+                pip_cache_dir=None,
+                poetry_cache_dir=None,
+            )
+
+            def download(_url: str, destination: Path) -> None:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_bytes(payload)
+
+            with (
+                patch(
+                    "app_builder.python_runtime.get_environment",
+                    return_value=environment,
+                ),
+                patch(
+                    "app_builder.python_runtime._download_file",
+                    side_effect=download,
+                ) as download_file,
+            ):
+                first = _ensure_downloaded_file(
+                    "https://example.invalid/runtime.zip", digest
+                )
+                second = _ensure_downloaded_file(
+                    "https://example.invalid/runtime.zip", digest
+                )
+
+            self.assertEqual(first, second)
+            self.assertEqual(payload, first.read_bytes())
+            download_file.assert_called_once()
+            self.assertFalse(
+                any(path.suffix == ".tmp" for path in first.parent.iterdir())
+            )
+
+    def test_failed_download_does_not_poison_cache(self) -> None:
+        with TemporaryDirectory() as temp_dir_str:
+            environment = AppBuilderEnvironment(
+                cache_root=Path(temp_dir_str),
+                install_root=Path(temp_dir_str),
+                pip_cache_dir=None,
+                poetry_cache_dir=None,
+            )
+
+            def fail_download(_url: str, destination: Path) -> None:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_bytes(b"partial")
+                raise RuntimeError("connection lost")
+
+            with (
+                patch(
+                    "app_builder.python_runtime.get_environment",
+                    return_value=environment,
+                ),
+                patch(
+                    "app_builder.python_runtime._download_file",
+                    side_effect=fail_download,
+                ),
+                self.assertRaisesRegex(RuntimeError, "connection lost"),
+            ):
+                _ensure_downloaded_file("https://example.invalid/runtime.zip")
+
+            expected = environment.download_path("https://example.invalid/runtime.zip")
+            self.assertFalse(expected.exists())
+            self.assertFalse(
+                expected.parent.exists()
+                and any(path.suffix == ".tmp" for path in expected.parent.iterdir())
+            )
+
+    def test_digest_mismatch_does_not_poison_cache(self) -> None:
+        with TemporaryDirectory() as temp_dir_str:
+            environment = AppBuilderEnvironment(
+                cache_root=Path(temp_dir_str),
+                install_root=Path(temp_dir_str),
+                pip_cache_dir=None,
+                poetry_cache_dir=None,
+            )
+
+            def download(_url: str, destination: Path) -> None:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_bytes(b"unexpected content")
+
+            url = "https://example.invalid/runtime.zip"
+            with (
+                patch(
+                    "app_builder.python_runtime.get_environment",
+                    return_value=environment,
+                ),
+                patch(
+                    "app_builder.python_runtime._download_file",
+                    side_effect=download,
+                ),
+                self.assertRaisesRegex(RuntimeError, "did not match expected"),
+            ):
+                _ensure_downloaded_file(url, "sha256:" + "0" * 64)
+
+            self.assertFalse(environment.download_path(url).exists())
 
     def test_source_marker_records_python_org_package_origin(self) -> None:
         with TemporaryDirectory() as temp_dir_str:


### PR DESCRIPTION
## Summary

- centralize app-builder-owned environment settings behind a lazy, cached `get_environment()` contract
- move Python.org and ExeWrap archives from `%TEMP%` into a URL-keyed, user-local cache with locking, digest validation, and atomic promotion
- route managed-version bootstrap, pip, and Poetry subprocesses through the resolved cache environment while preserving explicit `PIP_CACHE_DIR` and `POETRY_CACHE_DIR`
- add `app-builder cache path` and `app-builder cache info`, typo warnings for unknown `APP_BUILDER_*` names, CI guidance, and current user documentation

## Why

Clean CI workspaces currently redownload the largest app-builder inputs because runtime archives live under the operating-system temp directory and pip/Poetry cache placement is not coordinated. `APP_BUILDER_CACHE_ROOT` now provides one runner-controlled tree without putting machine policy into `app_builder.yaml`.

## Validation

- `python -m unittest discover -s test` - 215 tests passed
- `python -m mypy app_builder app_builder_meta test` - clean
- real CLI smoke test of `cache path`, `cache info`, derived pip/Poetry paths, and an unknown-variable spelling warning
- rebased onto current `1.x`, retaining the latest end-user installation documentation

Closes #67