### PR TITLE
Release app-builder 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "app-builder"
-version = "1.5.0"
+version = "1.6.0"
 description = "Schema-first Windows application builder for Python-focused apps."
 readme = "README.md"
 requires-python = ">=3.11,<4.0"


### PR DESCRIPTION
## Release intent\n\nPrepare app-builder 1.6.0 from the current 1.x default branch.\n\nThis minor release brings together the user-facing work merged since 1.5.0:\n\n- package inherited Start Menu icons automatically, including remapped icon paths, while keeping installer.icon optional (#72);\n- explain the supported end-user Windows installation, upgrade, PATH, verification, and removal workflow in the shipped documentation (#73);\n- provide configurable, reusable, concurrency-safe download and tool caches, plus pp-builder cache path and pp-builder cache info diagnostics (#74).\n\n## Versioning\n\nThis is a minor release because it adds backward-compatible installer and CLI capabilities. Historical 1.5.0 bridge examples and fixtures remain unchanged.\n\n## Validation\n\n- python -m unittest discover -s test: 215 tests passed\n- python -m black --check .: 62 files clean\n- python -m mypy .: 61 source files clean\n\nAfter merge, the release will be built from the merged 1.x commit, installed on Windows, verified, and then published with checksummed release assets.